### PR TITLE
FIX: SCSS handling

### DIFF
--- a/core/modules/modSaturne.class.php
+++ b/core/modules/modSaturne.class.php
@@ -110,7 +110,7 @@ class modSaturne extends DolibarrModules
             // Set this to 1 if module has its own theme directory (theme)
             'theme' => 0,
             // Set this to relative path of css file if module has its own css file
-            'css' => ['/saturne/css/scss/modules/picto/_picto.scss'],
+            'css' => ['/saturne/css/scss/modules/picto/_picto.scss.php'],
             // Set this to relative path of js file if module must load a js on all pages
             'js' => [],
             // Set here all hooks context managed by module. To find available hook context, make a "grep -r '>initHooks(' *" on source code. You can also set hook context to 'all'

--- a/css/scss/modules/picto/_picto.scss.php
+++ b/css/scss/modules/picto/_picto.scss.php
@@ -1,3 +1,5 @@
+<?php header("Content-Type: text/css"); ?>
+
 .pictoModule {
   vertical-align: middle;
   text-align: left;


### PR DESCRIPTION
Few weeks ago I created a PR because there is a bug on display for a picto.
[PR 811 in DoliSMQ](https://github.com/Evarisk/DoliSMQ/pull/811)

Your answer was that I should not have installed the saturne framework, but it was installed in its latest version on my instance.

After some investigation, I found that I have a mime type error in my laptop
```
The stylesheet  http://127.0.0.1/***/htdocs/custom/saturne/css/scss/modules/picto/_picto.scss?lang=fr_FR&theme=eldy&userid=1&entity=1&layout=classic&version=17.0.2&revision=437 was not loaded because its MIME type, « application/octet-stream », is not  « text/css ».
```
I serve Dolibarr with nginx and if you do not encounter this error, it's probably because you use an apache server which don't use MIME type by default.

##### So there is different way to solve this error:
1. Replace this .scss extension of this file  by .css I don't fully understand why you use a scss class here because it is a standard css class with no computed information.
2. Add .php after .scss  in order to change mime type directly in PHP with ```header("Content-Type: text/css");```
3. Ask each people installing this module to change its nginx config like it's done [here](https://www.cyberciti.biz/faq/how-to-override-content-type-with-nginx-web-server/)
4. Load ```saturne.min.css``` containing this class compiled in module descriptor instead of ```_picto.scss``` I think it is the best solution 

PS: I have a similar error in DoliSMQ with ```dolismq/css/scss/modules/_menu.scss```