### PR TITLE
FIX: do not try to get numeric classes

### DIFF
--- a/class/actions_saturne.class.php
+++ b/class/actions_saturne.class.php
@@ -213,7 +213,7 @@ class ActionsSaturne
 
 				<?php
 			}
-        } elseif (preg_match('/categorycard/', $parameters['context']) && preg_match('/viewcat.php/', $_SERVER['PHP_SELF'])) {
+        } elseif (preg_match('/categorycard/', $parameters['context']) && preg_match('/viewcat.php/', $_SERVER['PHP_SELF']) && !is_numeric(GETPOST('type'))) {
             $id   = GETPOST('id');
             $type = GETPOST('type');
 
@@ -359,7 +359,7 @@ class ActionsSaturne
 					}
 				}
 			}
-        } elseif (preg_match('/categorycard/', $parameters['context'])) {
+        } elseif (preg_match('/categorycard/', $parameters['context']) && !is_numeric(GETPOST('type'))) {
             global $langs;
 
             $elementId = GETPOST('element_id');


### PR DESCRIPTION
When navigating through categories, the breadcrumb link towards parent category contains a numeral identifier for the type instead of a class name, resulting in the `saturne_fetch_all_object_type() ` provoking an error 500.

I suggest testing the type before entering the hook.