### PR TITLE
#898 [Lib] fix: saturne_get_object_metadata should not replace filled…

### DIFF
--- a/lib/object.lib.php
+++ b/lib/object.lib.php
@@ -664,7 +664,7 @@ function saturne_get_objects_metadata(string $type = ''): array
                 if (!empty($objectMetadata['langfile'])) {
                     $langs->load($objectMetadata['langfile']);
                 }
-                if (dol_strlen($type) > 0) {
+                if (dol_strlen($type) > 0 && empty($otherNameType)) {
                     $otherNameType = (!empty(array_search($type, $objectMetadata)) ? $objectType : '');
                 }
             }


### PR DESCRIPTION
… var with empty space