### PR TITLE
fix: avoid edge case error message in log

### DIFF
--- a/class/saturnesignature.class.php
+++ b/class/saturnesignature.class.php
@@ -578,8 +578,12 @@ class SaturneSignature extends SaturneObject
      */
     public function fetchSignatories(int $fk_object, string $object_type, string $morefilter = '1 = 1')
     {
-        $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND ' . $morefilter . ' AND object_type="' . $object_type . '"' . ' AND status > 0'];
-        return $this->fetchAll('', '', 0, 0, $filter);
+        if (!empty($fk_object)) {
+            $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND ' . $morefilter . ' AND object_type="' . $object_type . '"' . ' AND status > 0'];
+            return $this->fetchAll('', '', 0, 0, $filter);
+        } else {
+            return [];
+        }
     }
 
     /**

--- a/class/saturnesignature.class.php
+++ b/class/saturnesignature.class.php
@@ -545,21 +545,25 @@ class SaturneSignature extends SaturneObject
      */
     public function fetchSignatory(string $role, int $fk_object, string $object_type)
     {
-        $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND status > 0 AND object_type="' . $object_type . '"'];
-        if (strlen($role)) {
-            $filter['customsql'] .= ' AND role = "' . $role . '"';
-            return $this->fetchAll('', '', 0, 0, $filter);
-        } else {
-            $signatories = $this->fetchAll('', '', 0, 0, $filter);
-            if (!empty($signatories) && $signatories > 0) {
-                $signatoriesArray = [];
-                foreach ($signatories as $signatory) {
-                    $signatoriesArray[$signatory->role][$signatory->id] = $signatory;
-                }
-                return $signatoriesArray;
+        if (!empty($fk_object)) {
+            $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND status > 0 AND object_type="' . $object_type . '"'];
+            if (strlen($role)) {
+                $filter['customsql'] .= ' AND role = "' . $role . '"';
+                return $this->fetchAll('', '', 0, 0, $filter);
             } else {
-                return 0;
+                $signatories = $this->fetchAll('', '', 0, 0, $filter);
+                if (!empty($signatories) && $signatories > 0) {
+                    $signatoriesArray = [];
+                    foreach ($signatories as $signatory) {
+                        $signatoriesArray[$signatory->role][$signatory->id] = $signatory;
+                    }
+                    return $signatoriesArray;
+                } else {
+                    return 0;
+                }
             }
+        } else {
+            return 0;
         }
     }
 


### PR DESCRIPTION
in some edge case I've get Error in dolibarr log 


2024-10-29 14:57:01 ERR 89.91.85.217 Error, you call sanitizeVal() with a bad value for the check type. Data can't be sanitized.
2024-10-29 15:00:42 ERR 89.91.85.217 DoliDBMysqli::query SQL Error query: SELECT t.rowid,t.date_creation,t.tms,t.import_key,t.status,t.role,t.gender,t.civility,t.firstname,t.lastname,t.job
,t.email,t.phone,t.society_name,t.signature_date,t.signature_location,t.signature_comment,t.element_id,t.element_type,t.module_name,t.signature,t.stamp,t.signature_url,t.transaction_url,t.last_em
ail_sent_date,t.attendance,t.object_type,t.fk_object FROM llx_saturne_object_signature as t WHERE 1 = 1 AND t.entity IN (1) **AND fk_object =** AND status > 0 AND object_type = "user" AND role = "Us
erSignature" LIMIT 1
2024-10-29 15:00:42 ERR 89.91.85.217 DoliDBMysqli::query SQL Error message: DB_ERROR_SYNTAX You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server v
ersion for the right syntax to use near 'AND status > 0 AND object_type = "user" AND role = "UserSignature" LIMIT 1' at line 1


if fk_object is not defined => better to do not run SQL query => it's better than have error in log