### PR TITLE
 Add Postgresql compatibility to the framework

### DIFF
--- a/class/actions_saturne.class.php
+++ b/class/actions_saturne.class.php
@@ -203,7 +203,7 @@ class ActionsSaturne
 
             $signatory = new SaturneSignature($this->db);
 
-            $signatory->fetch(0, '', ' AND fk_object = ' . $id . ' AND status > 0 AND object_type = "user" AND role = "UserSignature"');
+            $signatory->fetch(0, '', ' AND fk_object = ' . $id . ' AND status > 0 AND object_type = \'user\' AND role = \'UserSignature\'');
 
             $pictoPath = dol_buildpath('/saturne/img/saturne_color.png', 1);
 
@@ -273,7 +273,7 @@ class ActionsSaturne
             $signatory = new SaturneSignature($this->db);
             $data      = json_decode(file_get_contents('php://input'), true);
 
-            $result = $signatory->fetch(0, '', ' AND fk_object = ' . $id . ' AND status > 0 AND object_type = "user" AND role = "UserSignature"');
+            $result = $signatory->fetch(0, '', ' AND fk_object = ' . $id . ' AND status > 0 AND object_type = \'user\' AND role = \'UserSignature\'');
             if ($result <= 0) {
                 $signatory->setSignatory($id, $user->element, 'user', [$id], 'UserSignature');
             }

--- a/class/saturnesignature.class.php
+++ b/class/saturnesignature.class.php
@@ -545,9 +545,9 @@ class SaturneSignature extends SaturneObject
      */
     public function fetchSignatory(string $role, int $fk_object, string $object_type)
     {
-        $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND status > 0 AND object_type="' . $object_type . '"'];
+        $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND status > 0 AND object_type=\'' . $object_type . '\''];
         if (strlen($role)) {
-            $filter['customsql'] .= ' AND role = "' . $role . '"';
+            $filter['customsql'] .= ' AND role = \'' . $role . '\'';
             return $this->fetchAll('', '', 0, 0, $filter);
         } else {
             $signatories = $this->fetchAll('', '', 0, 0, $filter);
@@ -574,7 +574,7 @@ class SaturneSignature extends SaturneObject
      */
     public function fetchSignatories(int $fk_object, string $object_type, string $morefilter = '1 = 1')
     {
-        $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND ' . $morefilter . ' AND object_type="' . $object_type . '"' . ' AND status > 0'];
+        $filter = ['customsql' => 'fk_object=' . $fk_object . ' AND ' . $morefilter . ' AND object_type=\'' . $object_type . '\'' . ' AND status > 0'];
         return $this->fetchAll('', '', 0, 0, $filter);
     }
 
@@ -646,7 +646,7 @@ class SaturneSignature extends SaturneObject
     {
         global $user;
 
-        $filter              = ['customsql' => ' role="' . $role . '" AND fk_object=' . $fk_object . ' AND status=1 AND object_type="' . $object_type . '"'];
+        $filter              = ['customsql' => ' role="' . $role . '" AND fk_object=' . $fk_object . ' AND status=1 AND object_type=\'' . $object_type . '\''];
         $signatoriesToDelete = $this->fetchAll('', '', 0, 0, $filter);
         if (!empty($signatoriesToDelete) && $signatoriesToDelete > 0) {
             foreach ($signatoriesToDelete as $signatoryToDelete) {

--- a/lib/object.lib.php
+++ b/lib/object.lib.php
@@ -80,9 +80,9 @@ function saturne_fetch_all_object_type(string $className = '', string $sortorder
 
     $sql = 'SELECT ';
     $sql .= $objectFields;
-    $sql .= ' FROM `' . MAIN_DB_PREFIX . $object->table_element . '` as t';
+    $sql .= ' FROM "' . MAIN_DB_PREFIX . $object->table_element . '" as t';
     if ($extraFieldManagement) {
-        $sql .= ' LEFT JOIN `' . MAIN_DB_PREFIX . $object->table_element . '_extrafields` as eft ON t.rowid = eft.fk_object';
+        $sql .= ' LEFT JOIN "' . MAIN_DB_PREFIX . $object->table_element . '_extrafields" as eft ON t.rowid = eft.fk_object';
     }
     if (dol_strlen($joinManagement) > 0) {
         $sql .= $joinManagement;

--- a/sql/update.sql
+++ b/sql/update.sql
@@ -14,40 +14,40 @@
 -- along with this program.  If not, see https://www.gnu.org/licenses/.
 
 -- 1.0.0
-ALTER TABLE `llx_element_openinghours` ADD `fk_user_modif` INT NULL AFTER `fk_user_creat`;
-ALTER TABLE `llx_element_openinghours` RENAME `llx_saturne_schedules`;
-ALTER TABLE `llx_saturne_schedules` CHANGE `tms` `tms` TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
-ALTER TABLE `llx_saturne_schedules` CHANGE `status` `status` INT(11) NOT NULL;
+ALTER TABLE llx_element_openinghours ADD fk_user_modif INT NULL AFTER fk_user_creat;
+ALTER TABLE llx_element_openinghours RENAME llx_saturne_schedules;
+ALTER TABLE llx_saturne_schedules CHANGE tms tms TIMESTAMP on update CURRENT_TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE llx_saturne_schedules CHANGE status status INT(11) NOT NULL;
 
 -- 1.1.0
-ALTER TABLE `llx_dolisirh_object_signature` ADD module_name VARCHAR(128) NULL AFTER element_type;
-UPDATE `llx_dolisirh_object_signature` SET module_name = 'dolisirh';
-INSERT INTO `llx_saturne_object_signature` (entity, date_creation, tms, import_key, status, role, firstname, lastname, email, phone, society_name, signature_date, signature_location, signature_comment, element_id, element_type, module_name, signature, stamp, last_email_sent_date, signature_url, transaction_url, object_type, fk_object)
-SELECT entity, date_creation, tms, import_key, status, role, firstname, lastname, email, phone, society_name, signature_date, signature_location, signature_comment, element_id, element_type, module_name, signature, stamp, last_email_sent_date, signature_url, transaction_url, object_type, fk_object FROM `llx_dolisirh_object_signature`;
-DROP TABLE `llx_dolisirh_object_signature`;
+ALTER TABLE llx_dolisirh_object_signature ADD module_name VARCHAR(128) NULL AFTER element_type;
+UPDATE llx_dolisirh_object_signature SET module_name = 'dolisirh';
+INSERT INTO llx_saturne_object_signature (entity, date_creation, tms, import_key, status, role, firstname, lastname, email, phone, society_name, signature_date, signature_location, signature_comment, element_id, element_type, module_name, signature, stamp, last_email_sent_date, signature_url, transaction_url, object_type, fk_object)
+SELECT entity, date_creation, tms, import_key, status, role, firstname, lastname, email, phone, society_name, signature_date, signature_location, signature_comment, element_id, element_type, module_name, signature, stamp, last_email_sent_date, signature_url, transaction_url, object_type, fk_object FROM llx_dolisirh_object_signature;
+DROP TABLE llx_dolisirh_object_signature;
 
-ALTER TABLE `llx_dolismq_dolismqdocuments` ADD module_name VARCHAR(128) NULL AFTER type;
-UPDATE `llx_dolismq_dolismqdocuments` SET module_name = 'dolismq';
-INSERT INTO `llx_saturne_object_documents` (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
-SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM `llx_dolismq_dolismqdocuments`;
-DROP TABLE `llx_dolismq_dolismqdocuments`;
-DROP TABLE `llx_dolismq_dolismqdocuments_extrafields`;
+ALTER TABLE llx_dolismq_dolismqdocuments ADD module_name VARCHAR(128) NULL AFTER type;
+UPDATE llx_dolismq_dolismqdocuments SET module_name = 'dolismq';
+INSERT INTO llx_saturne_object_documents (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
+SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM llx_dolismq_dolismqdocuments;
+DROP TABLE llx_dolismq_dolismqdocuments;
+DROP TABLE llx_dolismq_dolismqdocuments_extrafields;
 
-ALTER TABLE `llx_dolisirh_dolisirhdocuments` ADD module_name VARCHAR(128) NULL AFTER type;
-UPDATE `llx_dolismq_dolismqdocuments` SET module_name = 'dolisirh';
-INSERT INTO `llx_saturne_object_documents` (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
-SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM `llx_dolisirh_dolisirhdocuments`;
-DROP TABLE `llx_dolisirh_dolisirhdocuments`;
-DROP TABLE `llx_dolisirh_dolisirhdocuments_extrafields`;
+ALTER TABLE llx_dolisirh_dolisirhdocuments ADD module_name VARCHAR(128) NULL AFTER type;
+UPDATE llx_dolismq_dolismqdocuments SET module_name = 'dolisirh';
+INSERT INTO llx_saturne_object_documents (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
+SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM llx_dolisirh_dolisirhdocuments;
+DROP TABLE llx_dolisirh_dolisirhdocuments;
+DROP TABLE llx_dolisirh_dolisirhdocuments_extrafields;
 
-ALTER TABLE `llx_dolimeet_dolimeetdocuments` ADD module_name VARCHAR(128) NULL AFTER type;
-UPDATE `llx_dolimeet_dolimeetdocuments` SET module_name = 'dolimeet';
-INSERT INTO `llx_saturne_object_documents` (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
-SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM `llx_dolimeet_dolimeetdocuments`;
-DROP TABLE `llx_dolimeet_dolimeetdocuments`;
-DROP TABLE `llx_dolimeet_dolimeetdocuments_extrafields`;
+ALTER TABLE llx_dolimeet_dolimeetdocuments ADD module_name VARCHAR(128) NULL AFTER type;
+UPDATE llx_dolimeet_dolimeetdocuments SET module_name = 'dolimeet';
+INSERT INTO llx_saturne_object_documents (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
+SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM llx_dolimeet_dolimeetdocuments;
+DROP TABLE llx_dolimeet_dolimeetdocuments;
+DROP TABLE llx_dolimeet_dolimeetdocuments_extrafields;
 
-ALTER TABLE `llx_saturne_object_signature` ADD `attendance` SMALLINT NULL AFTER `transaction_url`;
+ALTER TABLE llx_saturne_object_signature ADD attendance SMALLINT NULL AFTER transaction_url;
 
 -- 1.1.1
 UPDATE llx_saturne_object_signature SET role = 'Responsible' WHERE role = 'TIMESHEET_SOCIETY_RESPONSIBLE';
@@ -62,16 +62,16 @@ UPDATE llx_saturne_object_signature SET role = 'Attendant' WHERE role = 'AUDIT_E
 UPDATE llx_saturne_object_signature SET role = 'Auditor' WHERE role = 'AUDIT_SOCIETY_ATTENDANT';
 
 -- 1.1.2
-ALTER TABLE `llx_digiriskdolibarr_digiriskdocuments` ADD module_name VARCHAR(128) NULL AFTER type;
-UPDATE `llx_digiriskdolibarr_digiriskdocuments` SET module_name = 'digiriskdolibarr';
-INSERT INTO `llx_saturne_object_documents` (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
-SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM `llx_digiriskdolibarr_digiriskdocuments`;
-DROP TABLE `llx_digiriskdolibarr_digiriskdocuments`;
-DROP TABLE `llx_digiriskdolibarr_digiriskdocuments_extrafields`;
-ALTER TABLE `llx_saturne_object_documents` CHANGE json json longtext;
+ALTER TABLE llx_digiriskdolibarr_digiriskdocuments ADD module_name VARCHAR(128) NULL AFTER type;
+UPDATE llx_digiriskdolibarr_digiriskdocuments SET module_name = 'digiriskdolibarr';
+INSERT INTO llx_saturne_object_documents (ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat)
+SELECT ref, ref_ext, entity, date_creation, tms, import_key, status, type, module_name, json, model_pdf, model_odt, last_main_doc, parent_type, parent_id, fk_user_creat FROM llx_digiriskdolibarr_digiriskdocuments;
+DROP TABLE llx_digiriskdolibarr_digiriskdocuments;
+DROP TABLE llx_digiriskdolibarr_digiriskdocuments_extrafields;
+ALTER TABLE llx_saturne_object_documents CHANGE json json longtext;
 
 -- 1.6.0
-ALTER TABLE `llx_saturne_object_signature` ADD `gender` VARCHAR(10) AFTER `role`;
-ALTER TABLE `llx_saturne_object_signature` ADD `civility` VARCHAR(6) AFTER `gender`;
-ALTER TABLE `llx_saturne_object_signature` ADD `job` VARCHAR(128) AFTER `lastname`;
-ALTER TABLE `llx_saturne_object_signature` ADD `json` longtext NULL AFTER `attendance`;
+ALTER TABLE llx_saturne_object_signature ADD gender VARCHAR(10) AFTER role;
+ALTER TABLE llx_saturne_object_signature ADD civility VARCHAR(6) AFTER gender;
+ALTER TABLE llx_saturne_object_signature ADD job VARCHAR(128) AFTER lastname;
+ALTER TABLE llx_saturne_object_signature ADD json longtext NULL AFTER attendance;


### PR DESCRIPTION
This merge request fixes a few PostgreSQL incompatibilities that I found on the Saturne framework when setting up Digiquali.

The main point here is changing strings in SQL, so as to use the standard single-quoting instead of the mysql double-quoting.

On the migration side there is also backtick-quoting for identifiers that is mysql-specific, the standard way being double-quoting.
