### PR TITLE
Ajout de la gestion des clés de type String

### DIFF
--- a/core/tpl/list/objectfields_list_build_sql_select.tpl.php
+++ b/core/tpl/list/objectfields_list_build_sql_select.tpl.php
@@ -89,7 +89,17 @@ foreach ($search as $key => $val) {
             if ($val == '-1' || ($val === '0' && (empty($object->fields[$key]['arrayofkeyval']) || !array_key_exists('0', $object->fields[$key]['arrayofkeyval'])))) {
                 $val = '';
             }
-            $mode_search = 2;
+            if (!empty($object->fields[$key]['arrayofkeyval'])) {
+                $keys = array_keys($object->fields[$key]['arrayofkeyval']);
+                $keysAreInt = count(array_filter($keys, 'is_int')) === count($keys);
+                if($keysAreInt){
+                    $mode_search = 2;
+                }else{
+                    $mode_search = 3;
+                }
+            } else  {
+                $mode_search = 2;
+            }
         }
         if (empty($object->fields[$key]['searchmulti'])) {
             if (!is_array($val) && $val != '') {


### PR DESCRIPTION
Dans Digiquali, le filtre type des modèles ne fonctionne pas car dans la définition de Type, le arrayofkeyval a des clés de type String. La fonction natural_search en $mode_search=2 n'accepte que des Int, il faut donc utiliser le mode 3 si les clés sont des String