### PR TITLE
[List] fix: unique contextpage and preserve non-visible search params

### DIFF
--- a/core/tpl/list/objectfields_list_header.tpl.php
+++ b/core/tpl/list/objectfields_list_header.tpl.php
@@ -408,6 +408,13 @@ print '</div>';
 
 print '</div>'; // end #saturne-filter-panel
 
+// Preserve non-visible search parameters as hidden inputs so they survive form submissions
+foreach ($search as $key => $val) {
+    if (array_key_exists($key, $object->fields) && empty($arrayfields['t.' . $key]['checked']) && $val !== '' && !is_array($val)) {
+        print '<input type="hidden" name="search_' . $key . '" value="' . dol_escape_htmltag($val) . '">';
+    }
+}
+
 print '<div class="div-table-responsive">'; // You can use div-table-responsive-no-min if you don't need reserved height for your table
 print '<table class="tagtable nobottomiftotal noborder liste' . ($moreForFilter ? ' listwithfilterbefore' : '') . '">';
 print '<thead>';

--- a/view/saturne_list.php
+++ b/view/saturne_list.php
@@ -66,7 +66,7 @@ $massaction = GETPOST('massaction', 'alpha');
 $toselect                                   = [];
 [$confirm, $contextpage, $optioncss, $mode] = ['', '', '', ''];
 $listParameters                             = saturne_load_list_parameters(basename(dirname(__FILE__)));
-$listParameters['contextpage']              = GETPOSTISSET('contextpage') ? GETPOST('contextpage', 'aZ') : $objectMetadata['hook_name_list'];
+$listParameters['contextpage']              = GETPOSTISSET('contextpage') ? GETPOST('contextpage', 'aZ') : $objectMetadata['hook_name_list'] . '_saturne';
 foreach ($listParameters as $listParameterKey => $listParameter) {
     $$listParameterKey = $listParameter;
 }
@@ -89,7 +89,7 @@ if (isModEnabled('categorie')) {
 // Initialize view objects
 $form = new Form($db);
 
-$hookmanager->initHooks([$contextpage, $object->element . 'saturnelist', 'saturnelist']);
+$hookmanager->initHooks([$contextpage, $objectMetadata['hook_name_list'] . '_saturne', 'saturnelist']);
 
 // Fetch optionals attributes and labels
 $extrafields->fetch_name_optionals_label($object->table_element);


### PR DESCRIPTION
## Summary

- Suffixe `_saturne` ajouté au `contextpage` pour éviter la collision avec les préférences de colonnes (`MAIN_SELECTEDFIELDS_projectlist`) des listes natives Dolibarr
- Mise à jour du second élément de `initHooks` pour correspondre au nouveau pattern de contextpage
- Ajout de `<input type="hidden">` pour les paramètres de recherche non-visibles dans le panneau filtre, afin que les filtres URL (ex: `search_usage_opportunity=1`) survivent aux soumissions du formulaire

## Related issues

Eoxia/reedcrm#613