### PR TITLE
[SaturneObject] fix: replace dolBuildUrl with http_build_query for Dolibarr 22 compat

### DIFF
--- a/class/saturneobject.class.php
+++ b/class/saturneobject.class.php
@@ -528,7 +528,8 @@ abstract class SaturneObject extends CommonObject
                 $query = array_merge($query, ['save_lastsearch_values' => 1]);
             }
         }
-        $url = dolBuildUrl($baseurl, $query);
+        // TODO: replace with dolBuildUrl($baseurl, $query) once Dolibarr 22 support is dropped (function introduced in Dolibarr 24)
+        $url = $baseurl . '?' . http_build_query($query);
 
         $linkclose = '';
         if (empty($noToolTip)) {


### PR DESCRIPTION
## Problème

`dolBuildUrl()` a été introduite dans Dolibarr 24 et n'existe pas en Dolibarr 22, ce qui fait planter `getNomUrl()` dans `SaturneObject`.

## Solution

Remplacement temporaire par `http_build_query()` le temps que le support Dolibarr 22 soit abandonné. Un TODO est laissé en commentaire pour revenir à `dolBuildUrl()` une fois la migration effectuée.

## Type de changement

- [x] Bug fix