### PR TITLE
#1339 [SQL] fix: add missing extrafields table for saturne_object_documents

### DIFF
--- a/sql/documents/llx_saturne_object_documents_extrafields.key.sql
+++ b/sql/documents/llx_saturne_object_documents_extrafields.key.sql
@@ -1,0 +1,17 @@
+-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see https://www.gnu.org/licenses/.
+
+ALTER TABLE llx_saturne_object_documents_extrafields ADD INDEX idx_saturne_object_documents_extrafields_rowid (rowid);
+ALTER TABLE llx_saturne_object_documents_extrafields ADD INDEX idx_saturne_object_documents_extrafields_fk_object(fk_object);

--- a/sql/documents/llx_saturne_object_documents_extrafields.sql
+++ b/sql/documents/llx_saturne_object_documents_extrafields.sql
@@ -1,0 +1,21 @@
+-- Copyright (C) 2021-2023 EVARISK <technique@evarisk.com>
+--
+-- This program is free software; you can redistribute it and/or modify
+-- it under the terms of the GNU General Public License as published by
+-- the Free Software Foundation; either version 3 of the License, or
+-- (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+-- GNU General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License
+-- along with this program. If not, see https://www.gnu.org/licenses/.
+
+create table llx_saturne_object_documents_extrafields(
+    rowid      integer AUTO_INCREMENT PRIMARY KEY,
+    tms        timestamp,
+    fk_object  integer NOT NULL,
+    import_key varchar(14)                          -- import key
+) ENGINE=innodb;


### PR DESCRIPTION
## Summary
- Ajout des fichiers SQL manquants pour la table `llx_saturne_object_documents_extrafields`
- La classe `SaturneDocuments` a `isextrafieldmanaged = 1` mais les fichiers SQL de création de la table extrafields n'existaient pas dans `sql/documents/`
- Sans cette table, tout `fetchAll` sur un objet héritant de `SaturneDocuments` échoue silencieusement (retourne `-1`) car le `LEFT JOIN` sur la table inexistante provoque une erreur SQL

## Test plan
- [ ] Vérifier que la table `llx_saturne_object_documents_extrafields` est créée après désactivation/réactivation du module Saturne
- [ ] Vérifier que le dashboard Digirisk affiche les bonnes dates du Document Unique (et non "N/A")
- [ ] Vérifier que `fetchAll` sur `RiskAssessmentDocument` retourne bien les enregistrements

Closes #1339