### PR TITLE
#1342 [Signature] fix: log email details in actioncomm on send_email

### DIFF
--- a/core/triggers/interface_99_modSaturne_SaturneTriggers.class.php
+++ b/core/triggers/interface_99_modSaturne_SaturneTriggers.class.php
@@ -197,7 +197,12 @@ class InterfaceSaturneTriggers extends DolibarrTriggers
                 } else {
                     $actioncomm->fk_user_action = $object->element_id;
                 }
-                $actioncomm->fk_element = $object->fk_object;
+                $actioncomm->fk_element   = $object->fk_object;
+                $actioncomm->email_msgid  = $object->context['email_msgid'] ?? '';
+                $actioncomm->email_from   = $object->context['email_from'] ?? '';
+                $actioncomm->email_to     = $object->context['email_to'] ?? '';
+                $actioncomm->email_subject = $object->context['email_subject'] ?? '';
+                $actioncomm->note_private  = $object->context['email_body'] ?? '';
                 $actioncomm->create($user);
                 break;
 

--- a/view/saturne_attendants.php
+++ b/view/saturne_attendants.php
@@ -240,7 +240,12 @@ if (empty($resHook)) {
             } elseif (!empty($conf->global->MAIN_MAIL_SMTPS_ID) || $conf->global->SATURNE_USE_ALL_EMAIL_MODE > 0) {
                 $result = $mailfile->sendfile();
                 if ($result) {
-                    $signatory->last_email_sent_date = dol_now();
+                    $signatory->last_email_sent_date      = dol_now();
+                    $signatory->context['email_msgid']    = $mailfile->msgid;
+                    $signatory->context['email_from']     = $from;
+                    $signatory->context['email_to']       = $sendto;
+                    $signatory->context['email_subject']  = $subject;
+                    $signatory->context['email_body']     = $message;
                     $signatory->update($user, true);
                     $signatory->setPending($user, false);
                     setEventMessages($langs->trans('SendEmailAt', $signatory->email), []);


### PR DESCRIPTION
## Changements
- Stockage du contexte email (email_msgid, email_from, email_to, email_subject, email_body) sur le signataire avant l'appel à setPending()
- Renseignement des champs email_msgid, email_from, email_to, email_subject et note_private sur l'ActionComm créé par le trigger SATURNE_SIGNATURE_PENDING_SIGNATURE

## Fichiers modifiés
- view/saturne_attendants.php
- core/triggers/interface_99_modSaturne_SaturneTriggers.class.php

## Issue
#1342
