### PR TITLE
#1346 [MediaLib] fix: guard $user->conf media gallery prefs with !empty

### DIFF
--- a/lib/medias.lib.php
+++ b/lib/medias.lib.php
@@ -48,13 +48,13 @@ function saturne_show_medias(string $moduleName, string $modulepart = 'ecm', str
 
 	$filearray = dol_dir_list($dir, 'files', 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ? SORT_DESC : SORT_ASC));
 
-    if ($user->conf->SATURNE_MEDIA_GALLERY_SHOW_TODAY_MEDIAS == 1) {
+    if (!empty($user->conf->SATURNE_MEDIA_GALLERY_SHOW_TODAY_MEDIAS)) {
         $yesterdayTimeStamp = dol_time_plus_duree(dol_now(), -1, 'd');
         $filearray = array_filter($filearray, function($file) use ($yesterdayTimeStamp) {
             return $file['date'] > $yesterdayTimeStamp;
         });
     }
-    if (getDolGlobalInt('SATURNE_MEDIA_GALLERY_SHOW_ALL_MEDIA_INFOS') && $user->conf->SATURNE_MEDIA_GALLERY_SHOW_UNLINKED_MEDIAS == 1) {
+    if (getDolGlobalInt('SATURNE_MEDIA_GALLERY_SHOW_ALL_MEDIA_INFOS') && !empty($user->conf->SATURNE_MEDIA_GALLERY_SHOW_UNLINKED_MEDIAS)) {
         $moduleObjectMedias = dol_dir_list($conf->$moduleNameLowerCase->multidir_output[$conf->entity ?? 1], 'files', 1, '', '.odt|.pdf|barcode|_mini|_medium|_small|_large');
         $filearray          = array_filter($filearray, function($file) use ($conf, $moduleNameLowerCase, $moduleObjectMedias) {
             $fileExists = array_search($file['name'], array_column($moduleObjectMedias, 'name'));


### PR DESCRIPTION
## Summary

Fix #1346 — supprime les warnings PHP `Undefined property: stdClass::$SATURNE_MEDIA_GALLERY_*` dans `lib/medias.lib.php`.

- L1 51 et 57 accédaient à `$user->conf->SATURNE_MEDIA_GALLERY_SHOW_TODAY_MEDIAS` / `_SHOW_UNLINKED_MEDIAS` sans vérifier l'existence de la propriété.
- Remplacé par `!empty(...)` — préserve la sémantique "défini et truthy" de l'ancien `== 1` et silence le warning sur PHP 8+.
- Le TPL `core/tpl/medias/medias_gallery_modal.tpl.php` utilisait déjà `isset()` / `!empty()` sur les mêmes propriétés ; la lib est maintenant alignée.

## Test plan

- [ ] Ouvrir une galerie médias avec un utilisateur n'ayant jamais touché aux prefs `SATURNE_MEDIA_GALLERY_*` → plus aucun warning PHP
- [ ] Activer le toggle "Show today medias" → le filtre s'applique comme avant
- [ ] Activer le toggle "Show unlinked medias" (avec `SATURNE_MEDIA_GALLERY_SHOW_ALL_MEDIA_INFOS` activé) → le filtre s'applique comme avant

🤖 Generated with [Claude Code](https://claude.com/claude-code)