### PR TITLE
#1345 [List] fix: use metadata create_url for core object create button

### DIFF
--- a/view/saturne_list.php
+++ b/view/saturne_list.php
@@ -240,6 +240,10 @@ saturne_header(0, '', $title, '', '', 0, 0, [], [], '', 'mod-' . $object->elemen
     </script>
 <?php
 
+if (!empty($objectMetadata['create_url'])) {
+    $createUrl = dol_buildpath('/' . $objectMetadata['create_url'], 1) . '?action=create';
+}
+
 require_once __DIR__ . '/../core/tpl/list/objectfields_list_build_sql_select.tpl.php';
 require_once __DIR__ . '/../core/tpl/list/objectfields_list_header.tpl.php';
 require_once __DIR__ . '/../core/tpl/list/objectfields_list_search_input.tpl.php';


### PR DESCRIPTION
## Changements
- Definition de $createUrl depuis $objectMetadata['create_url'] avant l'inclusion du template de liste
- Corrige la 404 sur le bouton + des listes Saturne pour les objets Dolibarr core (ex: project -> projet/card.php?action=create)
- Aucun impact sur les modules custom : si create_url est vide dans les metadonnees, la variable n'est pas definie et le fallback du template s'applique normalement

## Fichiers modifies
- view/saturne_list.php

## Issue
#1345