### PR TITLE
[CI] fix: fallback module name to lowercase repo on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,17 @@ jobs:
             - name: Resolve tag and module name
               id: meta
               run: |
-                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-                      echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-                      echo "module=${{ inputs.module }}" >> $GITHUB_OUTPUT
-                  elif [ "${{ github.event_name }}" = "workflow_call" ]; then
+                  if [ "${{ github.event_name }}" = "workflow_call" ]; then
                       echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
                       echo "module=${{ inputs.module }}" >> $GITHUB_OUTPUT
                   else
-                      echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-                      echo "module=${{ inputs.module }}" >> $GITHUB_OUTPUT
+                      if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                          echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+                      else
+                          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+                      fi
+                      repo="${GITHUB_REPOSITORY##*/}"
+                      echo "module=${repo,,}" >> $GITHUB_OUTPUT
                   fi
 
             - name: Check for release notes


### PR DESCRIPTION
## Summary

- Le job de release produit un zip nommé `module_-VERSION.zip` (nom du module vide) lorsqu'il est déclenché par un push de tag ou un `workflow_dispatch`. Constaté lors du release 23.0.0 (`module_-23.0.0.zip` au lieu de `module_saturne-23.0.0.zip`).
- L'étape `Resolve tag and module name` lisait `${{ inputs.module }}` dans la branche `else` (push de tag), mais cet input n'existe que dans `workflow_call` — donc `module` se résolvait en chaîne vide.
- Fallback ajouté : on extrait le nom du repo depuis `GITHUB_REPOSITORY` et on le convertit en minuscules (`${repo,,}`). Le comportement `workflow_call` est inchangé pour ne pas casser les modules enfants qui appellent ce workflow réutilisable.

## Test plan

- [ ] Tag push sur Saturne → zip nommé `module_saturne-X.X.X.zip`
- [ ] Workflow_dispatch sur Saturne → idem
- [ ] Workflow_call depuis un module enfant → comportement existant préservé (input `module` toujours utilisé)