### PR TITLE
[CI] fix: prefer inputs over event_name for module/tag resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,17 @@ jobs:
             - name: Resolve tag and module name
               id: meta
               run: |
-                  if [ "${{ github.event_name }}" = "workflow_call" ]; then
+                  if [ -n "${{ inputs.tag }}" ]; then
                       echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+                  elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                      echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+                  else
+                      echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+                  fi
+
+                  if [ -n "${{ inputs.module }}" ]; then
                       echo "module=${{ inputs.module }}" >> $GITHUB_OUTPUT
                   else
-                      if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-                          echo "tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
-                      else
-                          echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-                      fi
                       repo="${GITHUB_REPOSITORY##*/}"
                       echo "module=${repo,,}" >> $GITHUB_OUTPUT
                   fi


### PR DESCRIPTION
## Summary

- Le release de Digirisk 23.0.0 a produit un zip nommé `module_digirisk-23.0.0.zip` au lieu de `module_digiriskdolibarr-23.0.0.zip`.
- La cause : quand un workflow réutilisable est appelé via `workflow_call`, `github.event_name` reste à la valeur du trigger original du caller (`push` pour un tag-push), pas à `workflow_call`. Mon précédent fix (#1350) testait `github.event_name == workflow_call`, ce qui n'était jamais vrai → on tombait dans le else qui écrasait `inputs.module` avec le nom du repo (`digirisk` au lieu de `digiriskdolibarr`).
- Solution : tester directement `inputs.module` (présent uniquement en workflow_call) avec `[ -n "..." ]`. Plus de conditional sur `github.event_name`.

## Test plan

- [ ] Tag push direct sur Saturne → zip `module_saturne-X.X.X.zip` (inputs.module vide → fallback repo basename)
- [ ] Workflow_call depuis Digirisk avec `module: digiriskdolibarr` → zip `module_digiriskdolibarr-X.X.X.zip`
- [ ] Workflow_dispatch sans inputs → fallback repo basename