### PR TITLE
#1358 [MediaBlock] feat: sequential photo editor for multi-file upload

### DIFF
--- a/core/tpl/medias/photo_editor_modal.tpl.php
+++ b/core/tpl/medias/photo_editor_modal.tpl.php
@@ -64,11 +64,6 @@
         <!-- Toolbar -->
         <div class="saturne-photo-editor-toolbar">
 
-            <!-- Cancel / close -->
-            <button type="button" id="saturne-btn-cancel-photo" class="saturne-editor-btn saturne-editor-btn--cancel" title="<?php echo $langs->trans('Cancel'); ?>">
-                <i class="fas fa-times"></i>
-            </button>
-
             <!-- Drawing tools -->
             <button type="button" class="saturne-tool-btn saturne-editor-btn saturne-editor-btn--tool" data-mode="crop"     title="<?php echo $langs->trans('Crop'); ?>"><i class="fas fa-crop"></i></button>
             <button type="button" class="saturne-tool-btn saturne-editor-btn saturne-editor-btn--tool" data-mode="rotate"   title="<?php echo $langs->trans('Rotate'); ?>"><i class="fas fa-redo"></i></button>
@@ -87,11 +82,13 @@
             <!-- Undo -->
             <button type="button" id="saturne-btn-undo-photo" class="saturne-editor-btn saturne-editor-btn--undo" title="<?php echo $langs->trans('Undo'); ?>"><i class="fas fa-reply"></i></button>
 
-            <!-- Save (uploads, keeps modal open) -->
-            <button type="button" id="saturne-btn-validate-photo" class="saturne-editor-btn saturne-editor-btn--save" title="<?php echo $langs->trans('Save'); ?>"><i class="fas fa-save"></i></button>
-
-            <!-- OK (closes modal) -->
-            <button type="button" id="saturne-btn-ok-photo" class="saturne-editor-btn saturne-editor-btn--ok" title="OK"><i class="fas fa-check"></i></button>
+            <!-- Cancel + OK grouped on the right -->
+            <div class="saturne-photo-editor-toolbar__actions">
+                <button type="button" id="saturne-btn-cancel-photo" class="saturne-editor-btn saturne-editor-btn--cancel" title="<?php echo $langs->trans('Cancel'); ?>">
+                    <i class="fas fa-times"></i>
+                </button>
+                <button type="button" id="saturne-btn-ok-photo" class="saturne-editor-btn saturne-editor-btn--ok" title="OK"><i class="fas fa-check"></i></button>
+            </div>
         </div>
 
     </div>

--- a/css/scss/modules/medias/_photo-editor.scss
+++ b/css/scss/modules/medias/_photo-editor.scss
@@ -204,14 +204,22 @@
     align-items: center;
     font-size: 14px;
 
-    &--cancel   { background-color: #f39c12; }
+    &--cancel   { background-color: #e74c3c; }
     &--tool     { background-color: #34495e; }
     &--undo     { background-color: #7f8c8d; }
-    &--save     { background-color: #2ecc71; }
     &--ok       { background-color: #2ecc71; font-size: 1.1em; }
 
     &.active,
     &--tool.active { background-color: #3498db; }
+}
+
+/* ── Toolbar actions group (cancel + OK, right-aligned) ──────────────────── */
+
+.saturne-photo-editor-toolbar__actions {
+    margin-left: auto;
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
 }
 
 /* ── Pencil tool container ────────────────────────────────────────────────── */

--- a/js/modules/mediaBlock.js
+++ b/js/modules/mediaBlock.js
@@ -92,12 +92,14 @@ window.saturne.mediaBlock.onPhotoSelected = function() {
     }
   }
 
-  window.saturne.photoEditor.openFile(files[0], function(blob) {
-    window.saturne.mediaBlock.uploadBlob(blob, module, subdir, block);
-  });
+  // Convert FileList to Array before clearing the input — browsers invalidate
+  // the FileList object when input.val('') is called, so async callbacks lose access
+  var filesArray = Array.prototype.slice.call(files);
 
   // Reset input so the same file can be re-selected if needed
   input.val('');
+
+  window.saturne.mediaBlock.openFilesSequentially(filesArray, 0, module, subdir, block);
 };
 
 /**
@@ -175,5 +177,32 @@ window.saturne.mediaBlock.uploadBlob = function(blob, module, subdir, block, ori
         block.find('.saturne-media-gallery').replaceWith(updatedGallery);
       }
     }
+  });
+};
+
+/**
+ * Open each file in the photo editor sequentially.
+ * After the user validates one photo the editor re-opens automatically for the next.
+ *
+ * @memberof Saturne_MediaBlock
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @param   {FileList} files  Files to process
+ * @param   {number}   index  Current index
+ * @param   {string}   module Module name
+ * @param   {string}   subdir Sub-directory
+ * @param   {jQuery}   block  The .linked-medias block element
+ * @returns {void}
+ */
+window.saturne.mediaBlock.openFilesSequentially = function(files, index, module, subdir, block) {
+  if (index >= files.length) {
+    return;
+  }
+
+  window.saturne.photoEditor.openFile(files[index], function(blob) {
+    window.saturne.mediaBlock.uploadBlob(blob, module, subdir, block);
+    window.saturne.mediaBlock.openFilesSequentially(files, index + 1, module, subdir, block);
   });
 };

--- a/js/modules/photoEditor.js
+++ b/js/modules/photoEditor.js
@@ -93,7 +93,6 @@ window.saturne.photoEditor.event = function() {
   var colorPicker  = document.getElementById('saturne-draw-color-picker');
   var cropDiv      = document.getElementById('saturne-crop-selection');
   var btnCancel    = document.getElementById('saturne-btn-cancel-photo');
-  var btnValidate  = document.getElementById('saturne-btn-validate-photo');
   var btnUndo      = document.getElementById('saturne-btn-undo-photo');
   var resDisplay   = document.getElementById('saturne-photo-resolution-display');
 
@@ -184,10 +183,21 @@ window.saturne.photoEditor.event = function() {
     window.saturne.photoEditor._close();
   });
 
-  // OK — close without triggering another save
+  // OK — save then close
   var btnOk = document.getElementById('saturne-btn-ok-photo');
   btnOk.addEventListener('click', function() {
+    var activeText = document.getElementById('saturne-floating-text-input');
+    if (activeText) {
+      activeText.blur();
+    }
+    var onSave = window.saturne.photoEditor._onSave;
+    // Close synchronously first so onSave can safely re-open the editor (e.g. sequential multi-file)
     window.saturne.photoEditor._close();
+    if (typeof onSave === 'function') {
+      canvas.toBlob(function(blob) {
+        onSave(blob);
+      }, 'image/jpeg', 0.85);
+    }
   });
 
   // Close on overlay click
@@ -202,21 +212,6 @@ window.saturne.photoEditor.event = function() {
     if (e.key === 'Escape' && modal.style.display !== 'none') {
       window.saturne.photoEditor._close();
     }
-  });
-
-  // Save — upload to server, keep modal open
-  btnValidate.addEventListener('click', function() {
-    var activeText = document.getElementById('saturne-floating-text-input');
-    if (activeText) {
-      activeText.blur();
-    }
-    var onSave = window.saturne.photoEditor._onSave;
-    if (typeof onSave !== 'function') {
-      return;
-    }
-    canvas.toBlob(function(blob) {
-      onSave(blob);
-    }, 'image/jpeg', 0.85);
   });
 };
 


### PR DESCRIPTION
#1358

## Changements

### Photo Editor Modal - UI
- Suppression du bouton Enregistrer (fa-save), doublon du bouton OK
- Boutons Annuler + OK groupes a droite de la toolbar via margin-left: auto
- Couleur du bouton Annuler : orange -> rouge (#e74c3c)
- Nouveau style SCSS .saturne-photo-editor-toolbar__actions

### Photo Editor JS - fix race condition
- Le handler OK appelle _close() avant le callback toBlob (async)
- Corrige le cas ou le modal suivant s'ouvrait puis se refermait immediatement lors d'un enchainement sequentiel

### MediaBlock JS - feat multi-upload
- L'editeur photo s'ouvre desormais sequentiellement pour chaque fichier selectionne
- Ajout de openFilesSequentially(files, index, ...) approche recursive avec callback
- Conversion du FileList en Array avant input.val avant de vider l'input pour eviter l'invalidation par le navigateur

## Fichiers modifies
- core/tpl/medias/photo_editor_modal.tpl.php
- css/scss/modules/medias/_photo-editor.scss
- js/modules/photoEditor.js
- js/modules/mediaBlock.js
