### PR TITLE
#1360 [MediaBlock] feat: show_upload option, basename subDir, gallery dedup fix, jQuery migration

### DIFF
--- a/css/scss/modules/medias/_media-block.scss
+++ b/css/scss/modules/medias/_media-block.scss
@@ -58,7 +58,6 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-top: 10px;
   padding: 0;
   background: transparent;
 

--- a/js/modules/mediaBlock.js
+++ b/js/modules/mediaBlock.js
@@ -171,10 +171,12 @@ window.saturne.mediaBlock.uploadBlob = function(blob, module, subdir, block, ori
     processData : false,
     contentType : false,
     complete    : function(resp) {
-      var doc            = new DOMParser().parseFromString(resp.responseText, 'text/html');
-      var updatedGallery = $(doc).find('.saturne-media-gallery');
-      if (updatedGallery.length && block && block.length) {
-        block.find('.saturne-media-gallery').replaceWith(updatedGallery);
+      var $doc       = $('<div>').html(resp.responseText);
+      var blockId    = block && block.attr('id');
+      var $srcBlock  = blockId ? $doc.find('#' + blockId) : $doc.find('.linked-medias').first();
+      var $gallery   = $srcBlock.find('.saturne-media-gallery');
+      if ($gallery.length && block && block.length) {
+        block.find('.saturne-media-gallery').replaceWith($gallery);
       }
     }
   });

--- a/lib/medias.lib.php
+++ b/lib/medias.lib.php
@@ -479,9 +479,11 @@ function saturne_render_media_block(string $moduleName, string $subDir = '', str
     $showPhoto   = isset($options['show_photo'])   ? $options['show_photo']   : true;
     $showAudio   = isset($options['show_audio'])   ? $options['show_audio']   : true;
     $showGallery = isset($options['show_gallery']) ? $options['show_gallery'] : true;
+    $showUpload  = isset($options['show_upload'])  ? $options['show_upload']  : true;
 
     $moduleNameLowerCase = dol_strtolower($moduleName);
-    $containerClass      = !empty($subDir) ? $subDir : 'media_dyn';
+    // Use only the last path segment as CSS class — subDir may contain slashes for deep paths
+    $containerClass      = !empty($subDir) ? basename($subDir) : 'media_dyn';
 
     // Compute the storage directory path.
     $uploadDir = !empty($conf->$moduleNameLowerCase->dir_output)
@@ -503,10 +505,12 @@ function saturne_render_media_block(string $moduleName, string $subDir = '', str
         $out .= '  <div class="fast-upload-options" data-from-type="' . dol_escape_htmltag($moduleNameLowerCase) . '" data-from-subtype="' . dol_escape_htmltag($containerClass) . '" data-from-subdir="' . dol_escape_htmltag($subDir) . '" data-prefix="' . dol_escape_htmltag($prefix) . '" data-rights="' . dol_escape_htmltag($rightString) . '"></div>';
         $out .= '  <div class="saturne-media-upload-block" data-module="' . dol_escape_htmltag($moduleNameLowerCase) . '" data-subdir="' . dol_escape_htmltag($subDir) . '">';
 
-        $out .= '    <label for="' . $idPrefix . 'upload-media" class="saturne-upload-label">';
-        $out .= '      <i class="fas fa-camera"></i>';
-        $out .= '      <input type="file" id="' . $idPrefix . 'upload-media" class="saturne-photo-upload" name="userfile[]" accept="image/*" data-error-not-image="' . dol_escape_htmltag($langs->trans('ErrorFileNotAnImage')) . '" multiple>';
-        $out .= '    </label>';
+        if ($showUpload) {
+            $out .= '    <label for="' . $idPrefix . 'upload-media" class="saturne-upload-label">';
+            $out .= '      <i class="fas fa-camera"></i>';
+            $out .= '      <input type="file" id="' . $idPrefix . 'upload-media" class="saturne-photo-upload" name="userfile[]" accept="image/*" data-error-not-image="' . dol_escape_htmltag($langs->trans('ErrorFileNotAnImage')) . '" multiple>';
+            $out .= '    </label>';
+        }
 
         $out .= '    <div class="saturne-media-gallery">';
 


### PR DESCRIPTION
Closes #1360

## Summary

- `lib/medias.lib.php` : option `show_upload` pour masquer le bouton camera selon le contexte (ex: objet verrouille) ; `basename($subDir)` pour eviter les slashes dans les noms de classes CSS
- `js/modules/mediaBlock.js` : fix doublon galerie apres upload en ciblant le bloc par son `id` ; remplacement de `DOMParser` (Vanilla JS) par `$(<div>).html(...)` (jQuery)
- `css/scss/modules/medias/_media-block.scss` : suppression du `margin-top: 10px` intrinseque sur `.saturne-media-upload-block` — l'espacement appartient au parent

## Test plan

- [ ] Uploader une photo via saturne_render_media_block — galerie se rafraichit sans doublon quand plusieurs blocs sont presents sur la meme page
- [ ] Passer show_upload: false — bouton camera absent, galerie toujours visible
- [ ] Verifier qu'il n'y a pas de margin-top non desiree sur le bloc dans differents contextes

Generated with Claude Code