### PR TITLE
#698 [MediaBlock] fix: gallery refresh fallback when prefix id not found in AJAX response

### DIFF
--- a/js/modules/mediaBlock.js
+++ b/js/modules/mediaBlock.js
@@ -173,7 +173,10 @@ window.saturne.mediaBlock.uploadBlob = function(blob, module, subdir, block, ori
     complete    : function(resp) {
       var $doc       = $('<div>').html(resp.responseText);
       var blockId    = block && block.attr('id');
-      var $srcBlock  = blockId ? $doc.find('#' + blockId) : $doc.find('.linked-medias').first();
+      var $srcBlock  = blockId ? $doc.find('#' + blockId) : $();
+      if (!$srcBlock.length) {
+        $srcBlock = $doc.find('.linked-medias').first();
+      }
       var $gallery   = $srcBlock.find('.saturne-media-gallery');
       if ($gallery.length && block && block.length) {
         block.find('.saturne-media-gallery').replaceWith($gallery);


### PR DESCRIPTION
## Changements

- Correction du callback `complete` dans `uploadBlob` : si la recherche par id exact echoue dans la reponse AJAX (cas ou le prefix HTML differe entre le DOM et la reponse serveur), on bascule automatiquement sur `.linked-medias.first()`
- La galerie se rafraichit desormais correctement apres chaque upload photo, quel que soit le prefix utilise par l'appelant

## Cause

`saturne_render_media_block` est appele dans la reponse AJAX de `action=uploadPhoto` sans le prefixe passe initialement dans la vue (ex. `quickcreation_`). Le DOM a donc un id `quickcreation_-master-media-row-container-photo` mais la reponse AJAX genere `master-media-row-container-photo`. La recherche par id echoue silencieusement, la galerie ne se met pas a jour.

## Fichier modifie

- `js/modules/mediaBlock.js`

## Issue

Eoxia/reedcrm#698