### PR TITLE
[Object][List] Désarchivage des éléments

### DIFF
--- a/class/saturneobject.class.php
+++ b/class/saturneobject.class.php
@@ -451,6 +451,23 @@ abstract class SaturneObject extends CommonObject
     }
 
     /**
+     * Set unarchived status (back to validated)
+     *
+     * @param  User      $user      Object user that modify
+     * @param  int<0,1>  $noTrigger 0 = launch triggers after, 1 = disable triggers
+     * @return int<-1,1>            Return integer 0 < if KO, 0 if not archived, > 0 if OK
+     */
+    public function setUnarchived(User $user, int $noTrigger = 0): int
+    {
+        // Protection : seul un élément archivé peut être désarchivé
+        if ((int) $this->status !== static::STATUS_ARCHIVED) {
+            return 0;
+        }
+
+        return $this->setStatusCommon($user, static::STATUS_VALIDATED, $noTrigger, strtoupper($this->element) . '_UNARCHIVE');
+    }
+
+    /**
      * Return array of data to show into a tooltip
      * This method must be implemented in each object class
      *

--- a/core/tpl/actions/list_massactions.tpl.php
+++ b/core/tpl/actions/list_massactions.tpl.php
@@ -59,3 +59,34 @@ if (($massaction == 'archive' || ($action == 'archive' && $confirm == 'yes')) &&
         }
     }
 }
+
+// Unarchive mass action
+if (($massaction == 'unarchive' || ($action == 'unarchive' && $confirm == 'yes')) && $permissiontoadd) {
+    if (!empty($toselect)) {
+        $nbOk      = 0;
+        $error     = 0;
+        $objectTmp = new $objectclass($db);
+        foreach ($toselect as $toSelectedID) {
+            $result = $objectTmp->fetch($toSelectedID);
+            if ($result > 0) {
+                $result = $objectTmp->setUnarchived($user, false);
+                if ($result > 0) {
+                    $nbOk++;
+                } elseif ($result < 0) {
+                    // 0 = élément non archivé (garde-fou) : ignoré silencieusement, pas bloquant
+                    setEventMessages($objectTmp->error, $objectTmp->errors, 'errors');
+                    $error++;
+                    break;
+                }
+            } else {
+                setEventMessages($objectTmp->error, $objectTmp->errors, 'errors');
+                $error++;
+                break;
+            }
+        }
+
+        if ($error == 0) {
+            setEventMessages($langs->trans('RecordsUnarchived', $nbOk), []);
+        }
+    }
+}

--- a/core/tpl/actions/object_workflow_actions.tpl.php
+++ b/core/tpl/actions/object_workflow_actions.tpl.php
@@ -82,3 +82,21 @@ if ($action == 'confirm_archive' && $permissiontoadd) {
         setEventMessages($object->error, [], 'errors');
     }
 }
+
+// Action to set status STATUS_VALIDATED back from STATUS_ARCHIVED
+if ($action == 'confirm_unarchive' && $permissiontoadd) {
+    $result = $object->setUnarchived($user, false);
+    if ($result > 0) {
+        // Set Unarchived OK
+        $urlToGo = str_replace('__ID__', $result, $backtopage);
+        // New method to autoselect project after a New on another form object creation
+        $urlToGo = preg_replace('/--IDFORBACKTOPAGE--/', $id, $urlToGo);
+        header('Location: ' . $urlToGo);
+        exit;
+        // Set Unarchived KO
+    } elseif (!empty($object->errors)) {
+        setEventMessages('', $object->errors, 'errors');
+    } else {
+        setEventMessages($object->error, [], 'errors');
+    }
+}

--- a/core/tpl/list/objectfields_list_header.tpl.php
+++ b/core/tpl/list/objectfields_list_header.tpl.php
@@ -101,7 +101,8 @@ $arrayOfMassActions = [
     //'generate_doc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("ReGeneratePDF"),
     //'builddoc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("PDFMerge"),
     //'presend'=>img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
-    'prearchive' => '<span class="fas fa-archive paddingrightonly"></span>' . $langs->trans('Archive')
+    'prearchive' => '<span class="fas fa-archive paddingrightonly"></span>' . $langs->trans('Archive'),
+    'preunarchive' => '<span class="fas fa-box-open paddingrightonly"></span>' . $langs->trans('Unarchive')
 ];
 
 if (!empty($permissiontodelete)) {
@@ -347,6 +348,10 @@ require_once DOL_DOCUMENT_ROOT . '/core/tpl/massactions_pre.tpl.php';
 
 if ($massaction == 'prearchive') {
     print $form->formconfirm($_SERVER['PHP_SELF'], $langs->trans('ConfirmMassArchive'), $langs->trans('ConfirmMassArchivingQuestion', count($toselect)), 'archive', null, '', 0, 200, 500, 1);
+}
+
+if ($massaction == 'preunarchive') {
+    print $form->formconfirm($_SERVER['PHP_SELF'], $langs->trans('ConfirmMassUnarchive'), $langs->trans('ConfirmMassUnarchivingQuestion', count($toselect)), 'unarchive', null, '', 0, 200, 500, 1);
 }
 
 if ($searchAll) {

--- a/langs/en_US/object.lang
+++ b/langs/en_US/object.lang
@@ -106,6 +106,11 @@ ConfirmMassArchivingQuestion = Are you sure you want to archive the %d record(s)
 
 # SetEventMessage mass action
 RecordsArchived = %d record(s) archived
+ConfirmMassUnarchive           = Bulk unarchiving confirmation
+ConfirmMassUnarchivingQuestion = Are you sure you want to unarchive the %d record(s) selected ?
+RecordsUnarchived = %d record(s) unarchived
+Unarchive = Unarchive
+Unarchived = Unarchived
 ObjectNotFound  = %s not found
 
 # Data

--- a/langs/fr_FR/object.lang
+++ b/langs/fr_FR/object.lang
@@ -108,6 +108,11 @@ ConfirmMassArchivingQuestion = Êtes-vous sur de vouloir archiver les %d enregis
 
 # SetEventMessage mass action - Notice mass action
 RecordsArchived = %d enregistrement(s) archivé(s)
+ConfirmMassUnarchive           = Confirmation du désarchivage en masse
+ConfirmMassUnarchivingQuestion = Êtes-vous sûr de vouloir désarchiver les %d enregistrement(s) sélectionné(s) ?
+RecordsUnarchived = %d enregistrement(s) désarchivé(s)
+Unarchive = Désarchiver
+Unarchived = Désarchivé
 ObjectNotFound  = %s non trouvé(e)
 
 # Data - Donnée

--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -901,6 +901,26 @@ function saturne_load_list_parameters(string $contexName): array
     return $listParameters;
 }
 
+/**
+ * Get the status search filter from POST, or a default set of statuses.
+ *
+ * Honors the (multiselect) status filter posted as an array of int. When the user
+ * has not selected anything, falls back to $defaultStatuses. Used by list views to
+ * make the "Archived" status option actually reachable while keeping a sane default.
+ *
+ * @param  int[] $defaultStatuses Default statuses applied when no filter is posted
+ * @return int[]                  Statuses to filter on
+ */
+function saturne_get_status_search_filter(array $defaultStatuses): array
+{
+    $posted = GETPOST('search_status', 'array:int');
+    if (is_array($posted) && !empty($posted)) {
+        return $posted;
+    }
+
+    return $defaultStatuses;
+}
+
 
 /**
  * Load pagination parameters for list


### PR DESCRIPTION
## Objectif
Ajouter la possibilité de **désarchiver** un objet saturne (ARCHIVED → VALIDATED), réutilisable par tous les modules. Symétrique à l'archivage existant.

## Changements
- `SaturneObject::setUnarchived()` (garde-fou : seul un archivé peut être désarchivé).
- Action de masse « Désarchiver » dans les listes (option `preunarchive` + confirmation + exécution).
- Handler fiche `confirm_unarchive` dans `object_workflow_actions.tpl.php`.
- Helper `saturne_get_status_search_filter()` : honore le multiselect statut (rend les archivés atteignables).
- Traductions fr_FR / en_US.

Statut cible du désarchivage : Validé (1).

Closes #1365