### PR TITLE
[Object] Garde serveur : objet verrouillé/archivé en lecture seule

### DIFF
--- a/class/saturneobject.class.php
+++ b/class/saturneobject.class.php
@@ -468,6 +468,20 @@ abstract class SaturneObject extends CommonObject
     }
 
     /**
+     * Is the object in a state where its content can still be modified?
+     *
+     * True only for draft/validated. Locked, archived (and deleted) objects are read-only.
+     * This is the server-side counterpart of the UI convention `status < STATUS_LOCKED`.
+     *
+     * @return bool True if content modifications are allowed
+     */
+    public function isModifiable(): bool
+    {
+        return (int) $this->status >= static::STATUS_DRAFT
+            && (int) $this->status < static::STATUS_LOCKED;
+    }
+
+    /**
      * Return array of data to show into a tooltip
      * This method must be implemented in each object class
      *

--- a/langs/en_US/object.lang
+++ b/langs/en_US/object.lang
@@ -79,6 +79,7 @@ AllSignatoriesMustHaveSigned     = All participants must have signed to lock %s
 ObjectMustBeValidatedToSendEmail = %s must be in (validated) status to send an email
 ObjectMustBeLockedToSendEmail    = %s must be in (locked) status to send an email
 ObjectMustBeLockedToArchive      = %s must be in status (locked) in order to archive it
+ObjectIsReadOnly                 = %s is read-only (locked or archived)
 
 # Confirm box
 ValidateObject          = Validate %s

--- a/langs/fr_FR/object.lang
+++ b/langs/fr_FR/object.lang
@@ -79,6 +79,7 @@ AllSignatoriesMustHaveSigned     = Tous les participants doivent avoir signé po
 ObjectMustBeValidatedToSendEmail = %s doit être au statut (validé) pour envoyer un email
 ObjectMustBeLockedToSendEmail    = %s doit être au statut (verrouillé) pour envoyer un email
 ObjectMustBeLockedToArchive      = %s doit être au statut (verrouillé) afin de pouvoir l'archiver
+ObjectIsReadOnly                 = %s est en lecture seule (verrouillé ou archivé)
 
 # Confirm box - Boite de confirmation
 ValidateObject          = Valider %s


### PR DESCRIPTION
Ajoute `SaturneObject::isModifiable()` (true seulement pour DRAFT/VALIDATED ; LOCKED/ARCHIVED/DELETED = lecture seule) — contrepartie serveur de la convention UI `status < STATUS_LOCKED` — et la clé `ObjectIsReadOnly` (fr/en).

Consommé par DigiQuali pour bloquer les modifications de contenu sur objets gelés.

Closes #1369