### PR TITLE
fix(category): avoid Undefined array key warning on custom category creation

### DIFF
--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -732,6 +732,29 @@ function saturne_create_category(string $label = '', string $type = '', int $fkP
 
     $category = new Categorie($db);
 
+    if (!empty($type) && !isset($category->MAP_ID[$type])) {
+        $customTags = [
+            'question'        => ['id' => 436301001, 'obj_class' => 'Question', 'obj_table' => 'digiquali_question'],
+            'sheet'           => ['id' => 436301002, 'obj_class' => 'Sheet', 'obj_table' => 'digiquali_sheet'],
+            'control'         => ['id' => 436301003, 'obj_class' => 'Control', 'obj_table' => 'digiquali_control'],
+            'survey'          => ['id' => 436301004, 'obj_class' => 'Survey', 'obj_table' => 'digiquali_survey'],
+            'questiongroup'   => ['id' => 436301005, 'obj_class' => 'QuestionGroup', 'obj_table' => 'digiquali_questiongroup'],
+            'accident'        => ['id' => 436302001, 'obj_class' => 'Accident', 'obj_table' => 'digiriskdolibarr_accident'],
+            'preventionplan'  => ['id' => 436302002, 'obj_class' => 'PreventionPlan', 'obj_table' => 'digiriskdolibarr_preventionplan'],
+            'firepermit'      => ['id' => 436302003, 'obj_class' => 'FirePermit', 'obj_table' => 'digiriskdolibarr_firepermit'],
+            'risk'            => ['id' => 436302004, 'obj_class' => 'Risk', 'obj_table' => 'digiriskdolibarr_risk'],
+            'meeting'         => ['id' => 436304001, 'obj_class' => 'Meeting', 'obj_table' => 'dolimeet_session'],
+            'trainingsession' => ['id' => 436304002, 'obj_class' => 'Trainingsession', 'obj_table' => 'dolimeet_session'],
+            'audit'           => ['id' => 436304003, 'obj_class' => 'Audit', 'obj_table' => 'dolimeet_session'],
+            'session'         => ['id' => 436304004, 'obj_class' => 'Session', 'obj_table' => 'dolimeet_session']
+        ];
+        if (isset($customTags[$type])) {
+            $category->MAP_ID[$type]        = $customTags[$type]['id'];
+            $category->MAP_OBJ_CLASS[$type] = $customTags[$type]['obj_class'];
+            $category->MAP_OBJ_TABLE[$type] = $customTags[$type]['obj_table'];
+        }
+    }
+
     $category->label       = $label;
     $category->type        = $type;
     $category->fk_parent   = $fkParent;


### PR DESCRIPTION
bonne intention, mais je ne mergerais pas sans retouche.

La PR #1373 ajoute 23 lignes dans saturne_create_category() pour injecter des types custom dans les maps Dolibarr quand $type n’existe pas, afin d’éviter un warning Undefined array key lors de la création de catégories custom. Elle cible develop, contient 1 commit et 1 fichier modifié.

Mon avis :

Points positifs

Le correctif est localisé et simple.
Il règle probablement le warning pour les types listés : question, sheet, control, survey, accident, risk, etc.
Il évite de modifier le cœur Dolibarr.

Points de vigilance

La liste $customTags est codée en dur dans une fonction générique. C’est fragile : Saturne devient dépendant de types DigiQuali, DigiRisk, DoliMeet, etc.
Si un type custom inconnu arrive, il n’y a pas de comportement explicite : on continue avec un $type non mappé.
Les IDs 436301001, 436302001, etc. méritent une constante ou une source centralisée.
Les checks ne sont pas totalement verts : GitHub indique 5 checks, avec PHPStan en échec et 10 erreurs + 1 warning, même si les erreurs visibles semblent concerner d’autres fichiers (admin/media.php, admin/documents.php).

Recommandation
Je demanderais une modification avant merge : déplacer $customTags dans une constante, une méthode dédiée ou une configuration de module, par exemple saturne_get_custom_category_type_mapping(). La fonction saturne_create_category() doit rester un “carrefour”, pas devenir un annuaire codé en dur.

Verdict : Approve avec réserve légère si urgence, sinon Request changes pour centraliser le mapping et documenter l’origine des IDs.