### PR TITLE
#1374 [List] fix: remove dead dolibarr-context setContextVars block

### DIFF
--- a/view/saturne_list.php
+++ b/view/saturne_list.php
@@ -257,16 +257,6 @@ if (empty($resHook)) {
 $title = $langs->trans(ucfirst($object->element) . 'List');
 saturne_header(0, '', $title, '', '', 0, 0, [], [], '', 'mod-' . $object->element . ' page-list bodyforlist');
 
-?>
-    <script nonce="<?php echo getNonce(); ?>">
-        Dolibarr.setContextVars(<?php print json_encode([
-            'DOL_VERSION'            => DOL_VERSION,
-            'MAIN_LANG_DEFAULT'      => 'fr_FR',
-            'DOL_LANG_INTERFACE_URL' => dol_buildpath('admin/tools/ui/experimental/experiments/dolibarr-context/langs-tool-interface.php', 1),
-        ]) ?>);
-    </script>
-<?php
-
 require_once __DIR__ . '/../core/tpl/list/objectfields_list_build_sql_select.tpl.php';
 
 if (empty($createUrl) && !empty($objectMetadata['create_url'])) {


### PR DESCRIPTION
Closes #1374

## Problème
Toute liste générique (`view/saturne_list.php`) lève en console à chaque chargement :
`ReferenceError: Dolibarr is not defined`.

## Cause
`saturne_list.php` émettait `Dolibarr.setContextVars({...})` (depuis #1287) sans jamais charger `dolibarr-context.umd.js`, donc `window.Dolibarr` est `undefined`. Les variables posées (`DOL_VERSION`, `MAIN_LANG_DEFAULT`, `DOL_LANG_INTERFACE_URL`) ne sont lues nulle part → code expérimental mort.

## Fix
Suppression du bloc (10 lignes). Aucun impact fonctionnel.

## Vérification (Playwright, liste opportunités)
- Avant : `PAGE ERRORS (1): ReferenceError: Dolibarr is not defined`
- Après : `PAGE ERRORS (0)` ; cartes KPI, inline-edit (AJAX `saturne_update_field.php` → `{"success":true}`), presets et aperçu intacts.