### PR TITLE
#1376 [SaturneDashboard] fix: undefined array key data in show_dashboard() on fresh install

### DIFF
--- a/class/saturnedashboard.class.php
+++ b/class/saturnedashboard.class.php
@@ -252,7 +252,7 @@ class SaturneDashboard
                     foreach ($dashboardGraphs as $keyElement => $dashboardGraph) {
                         $nbDataset = 0;
                         $uniqueKey = strip_tags($dashboardGraph['title']) . $keyElement;
-                        if (is_array($dashboardGraph['data']) && !empty($dashboardGraph['data'])) {
+                        if (isset($dashboardGraph['data']) && is_array($dashboardGraph['data']) && !empty($dashboardGraph['data'])) {
                             if ($dashboardGraph['dataset'] >= 2) {
                                 foreach ($dashboardGraph['data'] as $dashboardGraphDatasets) {
                                     unset($dashboardGraphDatasets[0]);
@@ -345,7 +345,7 @@ class SaturneDashboard
         if (!empty($dashboards['lists']) && is_array($dashboards['lists'])) {
             foreach ($dashboards['lists'] as $dashboardLists) {
                 foreach ($dashboardLists as $dashboardList) {
-                    if (is_array($dashboardList['data']) && !empty($dashboardList['data'])) {
+                    if (isset($dashboardList['data']) && is_array($dashboardList['data']) && !empty($dashboardList['data'])) {
                         print '<div id="graph-' . $dashboardList['name'] . '"' . (empty($dashboardList['noFullSize']) ? 'style="width: 100%"' : '') . '>';
 
                         if (!empty($dashboardList['name'])) {


### PR DESCRIPTION
Fixes #1376 - Add `isset()` guard before `is_array()` on `data` key at lines 255 and 348 to prevent PHP 8+ warnings when a graph or list builder does not define the `data` key.