### PR TITLE
fix: undefined array key modulepart and dir in saturne_banner_tab resArray

### DIFF
--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -512,16 +512,16 @@ function saturne_banner_tab(object $object, string $paramId = 'ref', string $mor
         $resHook = $hookmanager->executeHooks('saturneBannerTabCustomSubdir', $parameters, $object, $action); // Note that $action and $object may have been modified by some hooks
         if ($resHook > 0) {
             if (!empty($hookmanager->resArray)) {
-                if ($hookmanager->resArray['modulepart']) {
+                if (!empty($hookmanager->resArray['modulepart'])) {
                     $modulePart = $hookmanager->resArray['modulepart'];
                 }
-                if ($hookmanager->resArray['dir']) {
+                if (!empty($hookmanager->resArray['dir'])) {
                     $baseDir = $hookmanager->resArray['dir'];
                 }
-                if ($hookmanager->resArray['subdir']) {
+                if (!empty($hookmanager->resArray['subdir'])) {
                     $subDir = $hookmanager->resArray['subdir'];
                 }
-                if ($hookmanager->resArray['photoLimit']) {
+                if (!empty($hookmanager->resArray['photoLimit'])) {
                     $photoLimit = $hookmanager->resArray['photoLimit'];
                 }
             }


### PR DESCRIPTION
Replace direct access to hook `resArray` keys with `!empty()` checks to prevent PHP 8 `Undefined array key` warnings when those keys are absent from the hook result.