### PR TITLE
[Documents] fix: undefined property MANUAL_PDF_GENERATION warning

### DIFF
--- a/lib/documents.lib.php
+++ b/lib/documents.lib.php
@@ -236,7 +236,7 @@ function saturne_show_documents(string $modulepart, $modulesubdir, $filedir, str
 			}
 		}
 		$manualPdfGenerationConf = $moduleNameUpperCase . '_MANUAL_PDF_GENERATION';
-		if ($conf->global->$manualPdfGenerationConf > 0) {
+		if (!empty($conf->global->$manualPdfGenerationConf)) {
 			$out .= '<td></td>';
 		}
 		$out .= '</tr>';

--- a/lib/documents.lib.php
+++ b/lib/documents.lib.php
@@ -328,7 +328,7 @@ function saturne_show_documents(string $modulepart, $modulesubdir, $filedir, str
 				$out .= '<td class="nowrap right">' . dol_print_date($date, 'dayhour', 'tzuser') . '</td>';
 
 				// Show pdf generation icon
-				if ($conf->global->$manualPdfGenerationConf > 0) {
+				if (!empty($conf->global->$manualPdfGenerationConf)) {
 					$extension = pathinfo($file['name'], PATHINFO_EXTENSION);
 
 					$out .= '<td class="right">';


### PR DESCRIPTION
Fixes PHP 8 warning when MANUAL_PDF_GENERATION is not set in configuration.