### PR TITLE
fix: warning sur les modèles de documents par défaut non définis

### DIFF
--- a/core/tpl/admin/object/object_document_model_view.tpl.php
+++ b/core/tpl/admin/object/object_document_model_view.tpl.php
@@ -75,7 +75,7 @@ if (is_array($filelist) && !empty($filelist)) {
                 // Default
                 print '<td class="center">';
                 $defaultModelConf = strtoupper($moduleName) . '_' . strtoupper($documentParentType) . '_DEFAULT_MODEL';
-                if ($conf->global->$defaultModelConf == $name) {
+                if (getDolGlobalString($defaultModelConf) == $name) {
                     print img_picto($langs->trans('Default'), 'on');
                 } else {
                     print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=setdoc&model_name=' . $name . '&const=' . $module->scandir . '&label=' . urlencode($module->name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">' . img_picto($langs->trans('Disabled'), 'off') . '</a>';
@@ -124,7 +124,7 @@ if (is_array($filelist) && !empty($filelist)) {
                     // Default
                     print '<td class="center">';
                     $defaultModelConf = strtoupper($moduleName) . '_' . strtoupper($documentParentType) . '_DEFAULT_MODEL';
-                    if ($conf->global->$defaultModelConf == $customName) {
+                    if (getDolGlobalString($defaultModelConf) == $customName) {
                         print img_picto($langs->trans('Default'), 'on');
                     } else {
                         print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=setdoc&model_name=' . $customName . '&const=' . $module->custom_scandir . '&label=' . urlencode($module->custom_name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">' . img_picto($langs->trans('Disabled'), 'off') . '</a>';

--- a/core/tpl/admin/object/object_document_model_view.tpl.php
+++ b/core/tpl/admin/object/object_document_model_view.tpl.php
@@ -64,7 +64,9 @@ if (is_array($filelist) && !empty($filelist)) {
                 // Active
                 print '<td class="center">';
                 if (in_array($name, $def)) {
+                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=del&model_name=' . $name . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
                     print img_picto($langs->trans('Enabled'), 'switch_on');
+                    print '</a>';
                 } else {
                     print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=set&model_name=' . $name . '&const=' . $module->scandir . '&label=' . urlencode($module->name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
                     print img_picto($langs->trans('Disabled'), 'switch_off');


### PR DESCRIPTION
Remplacement de l'accès direct à \\->global->XXX\ par \getDolGlobalString\ pour éviter le Warning _Undefined property_ dans la vue des modèles de document, lorsque le modèle par défaut n'est pas encore configuré.