### PR TITLE
#1383 [List] Filtre classique par défaut + bascule volet par utilisateur

### DIFF
--- a/core/ajax/saturne_save_list_layout.php
+++ b/core/ajax/saturne_save_list_layout.php
@@ -90,4 +90,17 @@ if ($action === 'reset') {
     exit;
 }
 
+if ($action === 'set_filter_mode') {
+    $mode = GETPOST('mode', 'aZ09');
+    if (!in_array($mode, ['classic', 'panel'], true)) {
+        echo json_encode(['success' => false, 'error' => 'InvalidMode']);
+        exit;
+    }
+
+    $modeKey = saturne_list_filter_mode_param($listId);
+    $res     = dol_set_user_param($db, $conf, $user, [$modeKey => $mode]);
+    echo json_encode($res > 0 ? ['success' => true] : ['success' => false, 'error' => 'SaveFailed']);
+    exit;
+}
+
 echo json_encode(['success' => false, 'error' => 'UnknownAction']);

--- a/core/tpl/list/objectfields_list_header.tpl.php
+++ b/core/tpl/list/objectfields_list_header.tpl.php
@@ -146,7 +146,7 @@ if ($mode != 'pwa' && $mode != 'kanban') {
 // Build side filter panel content
 // --------------------------------------------------------------------
 $panelFilterBody    = '';
-$useSideFilterPanel = true;
+$useSideFilterPanel = !empty($useSideFilterPanel);
 
 // Panel i18n labels
 $filterBtnLabel = $langs->trans('Filters');
@@ -154,7 +154,7 @@ $applyBtnLabel  = $langs->trans('Apply');
 $resetBtnLabel  = $langs->trans('ResetFilters');
 
 // 0. Global search_all field (if used by calling page)
-if (!empty($fieldsToSearchAll)) {
+if ($useSideFilterPanel && !empty($fieldsToSearchAll)) {
     $searchAllPlaceholder = $langs->trans('SearchInAllFields');
     $panelFilterBody .= '<div class="saturne-filter-search-all-wrapper">';
     $panelFilterBody .= '<input type="text" class="flat saturne-filter-search-all-input" name="search_all" id="panel_search_all" placeholder="' . dol_escape_htmltag($searchAllPlaceholder) . '" value="' . dol_escape_htmltag($searchAll ?? '') . '">';
@@ -162,7 +162,7 @@ if (!empty($fieldsToSearchAll)) {
 }
 
 // 1. Category filter section inside panel
-if (isModEnabled('categorie') && $user->hasRight('categorie', 'read') && isset($categorie->MAP_OBJ_CLASS[$object->element])) {
+if ($useSideFilterPanel && isModEnabled('categorie') && $user->hasRight('categorie', 'read') && isset($categorie->MAP_OBJ_CLASS[$object->element])) {
     require_once DOL_DOCUMENT_ROOT . '/core/class/html.formcategory.class.php';
     $formCategory  = new FormCategory($db);
     $rawCategories = $formCategory->select_all_categories($object->element, '', '', 64, 0, 2); // outputmode=2 → full arbo with color
@@ -240,6 +240,10 @@ if ($toggleTitlePanelRaw === 'ToggleIncludeExclude') {
 $toggleTitlePanel = dol_escape_htmltag($toggleTitlePanelRaw);
 
 foreach ($object->fields as $key => $val) {
+    // Classic mode renders its own inline filter row; skip building the panel rows
+    if (!$useSideFilterPanel) {
+        continue;
+    }
     if (empty($arrayfields['t.' . $key]['checked'])) {
         continue;
     }
@@ -330,10 +334,13 @@ $newCardButton .= dolGetButtonTitle($langs->trans('ViewKanban'), '', 'fa fa-th-l
 $newCardButton .= dolGetButtonTitle($langs->trans('ViewPwa'), '', 'fa fa-mobile imgforviewmode', $_SERVER['PHP_SELF'] . '?mode=pwa' . preg_replace('/([&?])*mode=[^&]+/', '', $param), '', ($mode == 'pwa' ? 2 : 1), ['morecss' => 'reposition']);
 $cardButton     = dolGetButtonTitle($langs->trans('New' . ucfirst($object->element)), $helpText ?? '', 'fa fa-plus-circle', ($createUrl ?? dol_buildpath('custom/' . $object->module . '/view/' . $object->element . '/' . $object->element . '_card.php', 1) . '?action=create' . ($moreUrlParameters ?? '')), '', $permissiontoadd);
 
-// Filter panel toggle button — left side, in the title area
-$filterButton = dolGetButtonTitle($filterBtnLabel, '', 'fas fa-sliders-h', '#', 'saturne-filter-toggle', $activeFilterCount > 0 ? 2 : 1, ['morecss' => 'reposition']);
-if ($activeFilterCount > 0) {
-    $filterButton = '<span class="saturne-filter-btn-wrapper">' . $filterButton . dolGetBadge((string) $activeFilterCount, '', 'secondary') . '</span>';
+// Filter panel button — only in panel mode; opens the side filter panel
+$filterButton = '';
+if ($useSideFilterPanel) {
+    $filterButton = dolGetButtonTitle($filterBtnLabel, '', 'fas fa-sliders-h', '#', 'saturne-filter-toggle', $activeFilterCount > 0 ? 2 : 1, ['morecss' => 'reposition']);
+    if ($activeFilterCount > 0) {
+        $filterButton = '<span class="saturne-filter-btn-wrapper">' . $filterButton . dolGetBadge((string) $activeFilterCount, '', 'secondary') . '</span>';
+    }
 }
 $listTitle    = (($conf->browser->layout == 'classic' && $mode != 'pwa') ? $title : '') . ' ' . $cardButton . ' ' . $filterButton;
 
@@ -388,38 +395,40 @@ if (!empty($arrayOfMassActions)) {
     $selectedFields .= $form->showCheckAddButtons('checkforselect', 1);
 }
 
-// Side filter panel (fixed overlay, inside the form)
+// Side filter panel (fixed overlay, inside the form) — only in panel mode
 // --------------------------------------------------------------------
-print '<div id="saturne-filter-backdrop"></div>';
-print '<div id="saturne-filter-panel">';
+if ($useSideFilterPanel) {
+    print '<div id="saturne-filter-backdrop"></div>';
+    print '<div id="saturne-filter-panel">';
 
-// Panel header
-print '<div class="saturne-filter-panel-header">';
-print '<strong class="saturne-filter-panel-title"><span class="fa fa-sliders-h"></span>' . dol_escape_htmltag($filterBtnLabel) . '</strong>';
-print '<span class="saturne-filter-panel-close">&times;</span>';
-print '</div>';
+    // Panel header
+    print '<div class="saturne-filter-panel-header">';
+    print '<strong class="saturne-filter-panel-title"><span class="fa fa-sliders-h"></span>' . dol_escape_htmltag($filterBtnLabel) . '</strong>';
+    print '<span class="saturne-filter-panel-close">&times;</span>';
+    print '</div>';
 
-// Panel body
-print '<div class="saturne-filter-panel-body">';
+    // Panel body
+    print '<div class="saturne-filter-panel-body">';
 
-// Legend notice explaining the eye/eye-slash toggle icons
-print '<div class="saturne-filter-legend">';
-print '<div class="saturne-filter-legend-items">';
-print '<span class="saturne-filter-legend-include"><span class="far fa-eye"></span> Inclure</span>';
-print '<span class="saturne-filter-legend-exclude"><span class="far fa-eye-slash"></span> Exclure</span>';
-print '</div>';
-print '</div>';
+    // Legend notice explaining the eye/eye-slash toggle icons
+    print '<div class="saturne-filter-legend">';
+    print '<div class="saturne-filter-legend-items">';
+    print '<span class="saturne-filter-legend-include"><span class="far fa-eye"></span> Inclure</span>';
+    print '<span class="saturne-filter-legend-exclude"><span class="far fa-eye-slash"></span> Exclure</span>';
+    print '</div>';
+    print '</div>';
 
-print $panelFilterBody;
-print '</div>';
+    print $panelFilterBody;
+    print '</div>';
 
-// Panel footer
-print '<div class="saturne-filter-panel-footer">';
-print '<button type="submit" class="butAction">' . dol_escape_htmltag($applyBtnLabel) . '</button>';
-print '<button type="submit" class="liste_titre button_removefilter reposition" name="button_removefilter_x" value="x"><span class="fas fa-times"></span> ' . dol_escape_htmltag($resetBtnLabel) . '</button>';
-print '</div>';
+    // Panel footer
+    print '<div class="saturne-filter-panel-footer">';
+    print '<button type="submit" class="butAction">' . dol_escape_htmltag($applyBtnLabel) . '</button>';
+    print '<button type="submit" class="liste_titre button_removefilter reposition" name="button_removefilter_x" value="x"><span class="fas fa-times"></span> ' . dol_escape_htmltag($resetBtnLabel) . '</button>';
+    print '</div>';
 
-print '</div>'; // end #saturne-filter-panel
+    print '</div>'; // end #saturne-filter-panel
+}
 
 // Preserve non-visible search parameters as hidden inputs so they survive form submissions
 foreach ($search as $key => $val) {
@@ -434,6 +443,18 @@ if ($mode != 'kanban' && $mode != 'pwa' && !empty($listLayoutId)) {
     print '<div class="saturne-columns-controls" data-list-layout-id="' . dol_escape_htmltag($listLayoutId) . '">';
     print '<button type="button" class="saturne-columns-toggle" title="' . dol_escape_htmltag($langs->trans('CustomizeColumns')) . '"><span class="fas fa-table-columns"></span> ' . dol_escape_htmltag($langs->trans('CustomizeColumns')) . '</button>';
     print '<button type="button" class="saturne-columns-reset" title="' . dol_escape_htmltag($langs->trans('ResetColumns')) . '"><span class="fas fa-undo"></span> ' . dol_escape_htmltag($langs->trans('ResetColumns')) . '</button>';
+
+    // Filter display mode toggle: classic inline row <-> side panel (per-user)
+    if ($useSideFilterPanel) {
+        $filterModeLabel  = $langs->trans('SwitchFilterToClassic');
+        $filterModeIcon   = 'fas fa-bars';
+        $filterModeTarget = 'classic';
+    } else {
+        $filterModeLabel  = $langs->trans('SwitchFilterToPanel');
+        $filterModeIcon   = 'fas fa-sliders-h';
+        $filterModeTarget = 'panel';
+    }
+    print '<button type="button" class="saturne-filter-mode-switch" data-list-layout-id="' . dol_escape_htmltag($listLayoutId) . '" data-filter-mode="' . $filterModeTarget . '" title="' . dol_escape_htmltag($filterModeLabel) . '"><span class="' . $filterModeIcon . '"></span> ' . dol_escape_htmltag($filterModeLabel) . '</button>';
     print '</div>';
 }
 

--- a/core/tpl/list/objectfields_list_search_input.tpl.php
+++ b/core/tpl/list/objectfields_list_search_input.tpl.php
@@ -90,6 +90,10 @@ foreach ($object->fields as $key => $val) {
                 $showModeToggle = true;
                 $fieldMode = $search[$key . '_mode'] ?? GETPOST('search_' . $key . '_mode', 'alpha') ?: 'inc';
                 $isExc     = ($fieldMode === 'exc');
+                // visible=2 hides the field content in showInputField; force visible for the search input
+                if (isset($val['visible']) && (int) $val['visible'] === 2) {
+                    $object->fields[$key]['visible'] = 1;
+                }
                 print '<span class="saturne-filter-inline-wrapper">';
                 print '<input type="hidden" id="search_' . $key . '_mode" name="search_' . $key . '_mode" value="' . ($isExc ? 'exc' : 'inc') . '">';
                 $titleAttr = dol_escape_htmltag($fieldLabel) . ' - ' . $toggleTitle;

--- a/js/modules/filter.js
+++ b/js/modules/filter.js
@@ -58,6 +58,7 @@ window.saturne.filter.event = function() {
     $(document).on('click', '#saturne-filter-backdrop', window.saturne.filter.close);
     $(document).on('click', '.saturne-filter-panel-close', window.saturne.filter.close);
     $(document).on('click', '.saturne-filter-mode-toggle', window.saturne.filter.toggleMode);
+    $(document).on('click', '.saturne-filter-mode-switch', window.saturne.filter.toggleDisplayMode);
     $(document).on('keydown', window.saturne.filter.handleKeyDown);
 };
 
@@ -121,6 +122,38 @@ window.saturne.filter.toggleMode = function() {
     $input.val(exc ? 'exc' : 'inc');
     $(this).html(exc ? '<span class="far fa-eye-slash"></span>' : '<span class="far fa-eye"></span>');
     $(this).toggleClass('saturne-filter-mode-exc', exc).toggleClass('saturne-filter-mode-inc', !exc);
+};
+
+/**
+ * Toggle the list filter display mode (classic inline row <-> side panel),
+ * persist the per-user preference, then reload to re-render the chosen UI
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @param   {Event} event
+ * @returns {void}
+ */
+window.saturne.filter.toggleDisplayMode = function(event) {
+    event.preventDefault();
+    var $btn = $(this);
+    $.ajax({
+        url     : window.saturne.listColumns.url(),
+        method  : 'POST',
+        dataType: 'json',
+        data    : {
+            action : 'set_filter_mode',
+            token  : window.saturne.toolbox.getToken(),
+            list_id: $btn.data('list-layout-id'),
+            mode   : $btn.data('filter-mode')
+        },
+        success: function() {
+            window.location.reload();
+        },
+        error: function() {
+            window.location.reload();
+        }
+    });
 };
 
 /**

--- a/langs/en_US/saturne.lang
+++ b/langs/en_US/saturne.lang
@@ -267,3 +267,7 @@ SearchInAllFields    = Search in all fields…
 # List column customization
 CustomizeColumns = Columns
 ResetColumns = Reset
+
+# List filter display mode
+SwitchFilterToPanel = Filters in panel
+SwitchFilterToClassic = Inline filters

--- a/langs/fr_FR/saturne.lang
+++ b/langs/fr_FR/saturne.lang
@@ -286,3 +286,7 @@ SearchInAllFields    = Rechercher dans tous les champs…
 # List column customization
 CustomizeColumns = Colonnes
 ResetColumns = Réinitialiser
+
+# List filter display mode
+SwitchFilterToPanel = Filtres en volet
+SwitchFilterToClassic = Filtres en ligne

--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -1183,6 +1183,37 @@ function saturne_get_list_layout(string $listId): array
 }
 
 /**
+ * Build the user_param key holding a list's per-user filter display mode.
+ *
+ * @param  string $listId List identifier (e.g. the object element)
+ * @return string         Sanitized user_param key
+ */
+function saturne_list_filter_mode_param(string $listId): string
+{
+    return 'SATURNE_LIST_FILTER_MODE_' . strtoupper(preg_replace('/[^A-Za-z0-9_]/', '', $listId));
+}
+
+/**
+ * Read the per-user filter display mode saved for a list.
+ *
+ * @param  string $listId List identifier (e.g. the object element)
+ * @return string         'panel' when the user opted into the side panel, 'classic' otherwise (default)
+ */
+function saturne_get_list_filter_mode(string $listId): string
+{
+    global $user;
+
+    if (empty($listId)) {
+        return 'classic';
+    }
+
+    $param = saturne_list_filter_mode_param($listId);
+    $raw   = isset($user->conf->$param) ? $user->conf->$param : '';
+
+    return ($raw === 'panel') ? 'panel' : 'classic';
+}
+
+/**
  * Determine the inline-edit editor type for a list field.
  *
  * @param  array  $val Field definition (type, arrayofkeyval, noedit, ...)

--- a/tests/phpunit/unit/SaturneFunctionsTest.php
+++ b/tests/phpunit/unit/SaturneFunctionsTest.php
@@ -224,4 +224,56 @@ class SaturneFunctionsTest extends TestCase
 
         unset($_REQUEST['contextpage']);
     }
+
+    // ─── saturne_list_filter_mode_param ───────────────────────────────────────
+
+    public function testFilterModeParamUppercasesAndPrefixes(): void
+    {
+        $this->assertSame('SATURNE_LIST_FILTER_MODE_MYOBJECT', saturne_list_filter_mode_param('myobject'));
+    }
+
+    public function testFilterModeParamStripsSpecialChars(): void
+    {
+        $this->assertSame('SATURNE_LIST_FILTER_MODE_FOOBAR', saturne_list_filter_mode_param('foo-bar!'));
+    }
+
+    // ─── saturne_get_list_filter_mode ─────────────────────────────────────────
+
+    public function testGetFilterModeDefaultsToClassicWhenNoPref(): void
+    {
+        global $user;
+        $user       = new \stdClass();
+        $user->conf = new \stdClass();
+
+        $this->assertSame('classic', saturne_get_list_filter_mode('myobject'));
+    }
+
+    public function testGetFilterModeReturnsPanelWhenStored(): void
+    {
+        global $user;
+        $user       = new \stdClass();
+        $user->conf = new \stdClass();
+        $key        = saturne_list_filter_mode_param('myobject');
+
+        $user->conf->$key = 'panel';
+
+        $this->assertSame('panel', saturne_get_list_filter_mode('myobject'));
+    }
+
+    public function testGetFilterModeDefaultsToClassicOnInvalidValue(): void
+    {
+        global $user;
+        $user       = new \stdClass();
+        $user->conf = new \stdClass();
+        $key        = saturne_list_filter_mode_param('myobject');
+
+        $user->conf->$key = 'garbage';
+
+        $this->assertSame('classic', saturne_get_list_filter_mode('myobject'));
+    }
+
+    public function testGetFilterModeDefaultsToClassicOnEmptyListId(): void
+    {
+        $this->assertSame('classic', saturne_get_list_filter_mode(''));
+    }
 }

--- a/view/saturne_list.php
+++ b/view/saturne_list.php
@@ -157,6 +157,9 @@ require_once DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_array_fields.tpl.ph
 $listLayoutId     = $object->element;
 $listLayout       = saturne_get_list_layout($listLayoutId);
 $listColumnWidths = $listLayout['widths'];
+
+// Per-user filter display mode: classic inline row (default) vs side filter panel
+$useSideFilterPanel = (saturne_get_list_filter_mode($listLayoutId) === 'panel');
 if (!empty($listLayout['order'])) {
     $listColumnPos = 0;
     foreach ($listLayout['order'] as $colKey) {


### PR DESCRIPTION
Closes #1383

## Objectif
Le panneau de filtres latéral était codé en dur (`$useSideFilterPanel = true`) comme seul mode d'affichage des filtres des listes génériques saturne. Cette PR repasse au **filtre classique** (ligne sous les en-têtes) **par défaut**, et garde le **volet latéral** en option **activable par utilisateur**.

## Comportement
- **Défaut = classique** pour tout utilisateur sans préférence.
- Préférence **par utilisateur**, persistée dans `llx_user_param` (clé `SATURNE_LIST_FILTER_MODE_{listId}`, par liste — même mécanisme que la mise en page des colonnes).
- **Bouton bascule** dans la barre `saturne-columns-controls` : « Filtres en volet » ⇆ « Filtres en ligne ». AJAX + reload (réutilise l'endpoint `saturne_save_list_layout.php`).

## Changements
- `lib/saturne_functions.lib.php` : `saturne_list_filter_mode_param()` + `saturne_get_list_filter_mode()` (+ 5 tests PHPUnit).
- `core/ajax/saturne_save_list_layout.php` : action `set_filter_mode`.
- `view/saturne_list.php` : résolution de `$useSideFilterPanel` avant les TPL.
- `core/tpl/list/objectfields_list_header.tpl.php` : volet + bouton « Filtres » conditionnés au mode panel ; bouton bascule ajouté.
- `core/tpl/list/objectfields_list_search_input.tpl.php` : rendu correct des filtres `select`/`sellist:` en mode classique.
- `js/modules/filter.js` : handler `toggleDisplayMode`.
- `langs/{fr_FR,en_US}/saturne.lang` : libellés.

## Notes
- À iso-comportement, la **recherche globale** et le **filtre par catégories** restent des fonctions du **volet** (non présentes en mode classique). Les utilisateurs qui en ont besoin basculent en volet.
- `js/saturne.min.js` non committé ici : recompilé par la CI build-assets sur develop (convention CLAUDE.md).
- Vérifié bout-en-bout via Playwright (liste `product`) : défaut classique, bascule, persistance, ouverture du volet, retour classique.

> ⚠️ `develop` n'étant pas la branche par défaut, `Closes #1383` ne fermera pas l'issue automatiquement au merge — à fermer manuellement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)