### PR TITLE
#1385 [Document] fix: include module and entity in ErrorDirNotFound message

### DIFF
--- a/core/modules/saturne/modules_saturne.php
+++ b/core/modules/saturne/modules_saturne.php
@@ -774,7 +774,9 @@ class SaturneDocumentModel extends CommonDocGenerator
 
         $uploadDir = getMultidirOutput($object, $this->module);
         if (!$uploadDir) {
-            setEventMessages($langs->trans('ErrorDirNotFound'), [], 'errors');
+            // multidir_output is keyed on the current entity only; surface module + object entity
+            // so a missing key (e.g. cross-entity object in multicompany) is diagnosable.
+            setEventMessages($langs->trans('ErrorDirNotFound', $this->module . ' (entity ' . (int) $object->entity . ')'), [], 'errors');
             return -1;
         }
 


### PR DESCRIPTION
Closes #1385

### Problème
Dans `buildDocumentFilename()`, lorsque `getMultidirOutput($object, $this->module)` renvoie un chemin vide, le message était `ErrorDirNotFound` **sans argument** → « Répertoire introuvable » sans module ni entité, non diagnostiquable.

### Quand
`multidir_output` est mono-entité (core). Multicompany ne partage pas les répertoires des modules custom (Saturne) → pour un objet dont `entity` ≠ entité de session, la clé manque, chemin vide. Cas réel : Evarisk/Digirisk#4800 (DUER généré depuis une autre entité que celle du standard).

### Correctif
Exposer module + entité de l'objet dans le message :

```php
setEventMessages($langs->trans('ErrorDirNotFound', $this->module . ' (entity ' . (int) $object->entity . ')'), [], 'errors');
```

→ « Répertoire **digiriskdolibarr (entity 7)** introuvable… ». `php -l` OK. Aucune autre modification.

> ⚠️ Base `develop`, défaut du repo `main` → `Closes #1385` ne fermera pas l'issue automatiquement, à fermer à la main au merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)