### PR TITLE
#1387 [List] fix: guard $val['type'] access in saturne_list.php

### DIFF
--- a/view/saturne_list.php
+++ b/view/saturne_list.php
@@ -122,7 +122,7 @@ foreach ($object->fields as $key => $val) {
     if (GETPOST('search_' . $key, 'alpha') !== '') {
         $search[$key] = GETPOST('search_' . $key, 'alpha');
     }
-    if (in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
+    if (isset($val['type']) && in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
         $search[$key . '_dtstart'] = dol_mktime(0, 0, 0, GETPOSTINT('search_' . $key . '_dtstartmonth'), GETPOSTINT('search_' . $key . '_dtstartday'), GETPOSTINT('search_' . $key . '_dtstartyear'));
         $search[$key . '_dtend']   = dol_mktime(23, 59, 59, GETPOSTINT('search_' . $key . '_dtendmonth'), GETPOSTINT('search_' . $key . '_dtendday'), GETPOSTINT('search_' . $key . '_dtendyear'));
     }


### PR DESCRIPTION
@
## Contexte

Sur une page de liste générique (`saturne_list.php`), PHP 8 émet en boucle `Undefined array key "type"` (ligne 125), suivi de `Cannot modify header information` (sortie partie avant les en-têtes HTTP).

## Cause racine

La boucle ligne 125 lit `$val['type']` **sans garde**, alors que la **ligne 222 du même fichier** (logique identique) et toute la couche TPL de liste gardent déjà avec `isset($val['type'])`. Un champ sans clé `type` (interne/non visible) déclenche l'avertissement.

## Correctif

Une ligne, alignée sur la convention existante (ligne 222) :

```php
if (isset($val['type']) && in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
```

Closes #1387
@