### PR TITLE
#1389 [List] Rendre la ligne de filtres classique sticky

### DIFF
--- a/css/scss/modules/list-sticky/_list-sticky.scss
+++ b/css/scss/modules/list-sticky/_list-sticky.scss
@@ -17,6 +17,17 @@
 
     table.liste thead tr.liste_titre > th {
         background-color: #f4f5f7;
+        // Stick just below the classic inline filter row (its height is set by listStickyHeader.js; 0 in panel mode)
+        top: var(--saturne-filter-row-h, 0);
+    }
+
+    // Classic inline filter row (td cells) sits above the title row — keep it sticky too so the
+    // filter inputs stay visible while scrolling. In panel mode this row is absent (no effect).
+    table.liste thead tr.liste_titre_filter > td {
+        position: sticky;
+        top: 0;
+        z-index: 3;
+        background-color: #f4f5f7;
     }
 
     // The column-picker dropdown (Dolibarr .selectedfieldsleft) lives INSIDE its own header cell,

--- a/js/modules/listStickyHeader.js
+++ b/js/modules/listStickyHeader.js
@@ -46,4 +46,12 @@ window.saturne.listStickyHeader.apply = function() {
             this.style.maxHeight = h + 'px';
         }
     });
+
+    // Offset the sticky title row by the classic filter row height so both rows stay stacked
+    // (the filter row is absent in panel mode, leaving the title row pinned at the top).
+    $('.bodyforlist table.liste').each(function() {
+        var filterRow = this.querySelector('thead tr.liste_titre_filter');
+        var height    = filterRow ? Math.round(filterRow.getBoundingClientRect().height) : 0;
+        this.style.setProperty('--saturne-filter-row-h', height + 'px');
+    });
 };


### PR DESCRIPTION
Closes #1389

## Contexte
Depuis #1383, le filtre classique (ligne `tr.liste_titre_filter` en `<td>`) est le mode par défaut. Le header sticky existant (module `list-sticky`) ne collait que la ligne de titres (`thead th`) : en défilant, les champs de filtre disparaissaient.

## Changement
- `css/scss/modules/list-sticky/_list-sticky.scss` : la ligne de filtres (`tr.liste_titre_filter > td`) devient sticky (`top: 0`) ; la ligne de titres se cale juste en dessous via `top: var(--saturne-filter-row-h, 0)`.
- `js/modules/listStickyHeader.js` : mesure la hauteur de la ligne de filtres et alimente la variable CSS `--saturne-filter-row-h` (load + resize). En mode panel (pas de ligne de filtres), la variable vaut 0 → comportement inchangé.

## Vérification (Playwright, liste `product`)
Après défilement : ligne de filtres épinglée en haut du conteneur, ligne de titres empilée juste en dessous (offset = hauteur de la ligne de filtres), lignes de données défilant correctement sous le header. Mode panel non impacté.

`js/saturne.min.js` / `css/saturne.min.css` non committés : recompilés par la CI build-assets sur develop.

> ⚠️ `develop` n'étant pas la branche par défaut, `Closes #1389` ne fermera pas l'issue automatiquement au merge — à fermer manuellement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)