### PR TITLE
#1393 [Document] feat: add drag & drop upload on attached files tab

### DIFF
--- a/css/scss/style.scss
+++ b/css/scss/style.scss
@@ -12,6 +12,39 @@
   border: 5px solid #0d8aff;
 }
 
+/* Drag & drop dropzone for the attached-files upload area (saturne.document.js) */
+.attachareaformuserfile {
+  position: relative;
+
+  &.saturne-dropzone {
+    border: 2px dashed #c3d4e8;
+    border-radius: 8px;
+    padding: 12px 16px;
+    background: #fbfcfe;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+
+  &.attacharea-dragover {
+    border-style: dashed;
+    border-color: #0d8aff;
+    background: rgba(13, 138, 255, 0.08);
+  }
+}
+
+.saturne-dropzone-hint {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed #e3e9f2;
+  text-align: center;
+  font-size: 12px;
+  color: #6b7c93;
+
+  i {
+    margin-right: 6px;
+    color: #0d8aff;
+  }
+}
+
 tr.liste_titre th.liste_titre:not(.maxwidthsearch), tr.liste_titre td.liste_titre:not(.maxwidthsearch) { opacity: 1; }
 
 /* Force values on one colum for small screen */

--- a/js/modules/document.js
+++ b/js/modules/document.js
@@ -41,6 +41,7 @@ window.saturne.document = {};
  */
 window.saturne.document.init = function() {
 	window.saturne.document.event();
+	window.saturne.document.setupDropZone();
 };
 
 /**
@@ -55,6 +56,9 @@ window.saturne.document.event = function() {
   $(document).on('click', '#builddoc_generatebutton', window.saturne.document.displayLoader);
   $(document).on('click', '.pdf-generation', window.saturne.document.displayLoader);
   $(document).on('click', '.download-template', window.saturne.document.autoDownloadTemplate);
+  $(document).on('dragenter dragover', window.saturne.document.onDragOver);
+  $(document).on('dragleave', window.saturne.document.onDragLeave);
+  $(document).on('drop', window.saturne.document.onDrop);
 };
 
 /**
@@ -102,4 +106,154 @@ window.saturne.document.autoDownloadTemplate = function() {
     },
     error: function () {}
   });
+};
+
+/**
+ * Tell whether the current drag event carries files.
+ *
+ * @memberof Saturne_Framework_Document
+ *
+ * @since   1.7.0
+ * @version 1.7.0
+ *
+ * @param  {Object}  event Drag event.
+ * @return {boolean}       True when files are being dragged.
+ */
+window.saturne.document.isFileDrag = function(event) {
+  let dataTransfer = event.originalEvent ? event.originalEvent.dataTransfer : null;
+  return !!(dataTransfer && dataTransfer.types && Array.prototype.indexOf.call(dataTransfer.types, 'Files') !== -1);
+};
+
+/**
+ * Return the attached-files upload zone of the current page (empty jQuery set if none).
+ *
+ * @memberof Saturne_Framework_Document
+ *
+ * @since   1.7.0
+ * @version 1.7.0
+ *
+ * @return {Object} jQuery set for the upload zone.
+ */
+window.saturne.document.getUploadZone = function() {
+  return $('.attachareaformuserfile').first();
+};
+
+/**
+ * Turn the upload zone into a visible dropzone by appending a hint (icon + label)
+ * so the user knows where files can be dropped.
+ *
+ * @memberof Saturne_Framework_Document
+ *
+ * @since   1.7.0
+ * @version 1.7.0
+ *
+ * @return {void}
+ */
+window.saturne.document.setupDropZone = function() {
+  let zone = window.saturne.document.getUploadZone();
+  if (!zone.length || zone.find('.saturne-dropzone-hint').length) {
+    return;
+  }
+  let label = $('#saturne-drop-files-label').text();
+  if (!label) {
+    return;
+  }
+  zone.addClass('saturne-dropzone');
+  zone.append('<div class="saturne-dropzone-hint"><i class="fas fa-cloud-upload-alt"></i> ' + label + '</div>');
+};
+
+/**
+ * While a file is dragged anywhere on a page exposing the upload zone, make the
+ * whole page a valid drop target (so the browser never opens the file) and
+ * highlight the upload zone to show where the file will be sent.
+ *
+ * @memberof Saturne_Framework_Document
+ *
+ * @since   1.7.0
+ * @version 1.7.0
+ *
+ * @param  {Object} event Drag event.
+ * @return {void}
+ */
+window.saturne.document.onDragOver = function(event) {
+  if (!window.saturne.document.isFileDrag(event)) {
+    return;
+  }
+  let zone = window.saturne.document.getUploadZone();
+  if (!zone.length) {
+    return;
+  }
+  event.preventDefault();
+  zone.addClass('attacharea-dragover');
+};
+
+/**
+ * Remove the highlight once the file leaves the window.
+ *
+ * @memberof Saturne_Framework_Document
+ *
+ * @since   1.7.0
+ * @version 1.7.0
+ *
+ * @param  {Object} event Drag event.
+ * @return {void}
+ */
+window.saturne.document.onDragLeave = function(event) {
+  // relatedTarget is null only when the pointer actually leaves the window
+  if (event.originalEvent && event.originalEvent.relatedTarget === null) {
+    window.saturne.document.getUploadZone().removeClass('attacharea-dragover');
+  }
+};
+
+/**
+ * Inject the files dropped anywhere on the page into the upload form then trigger
+ * the upload.
+ *
+ * The dropped files are staged into the native file input (so the file name is
+ * shown like a manual selection), then the real "ENVOYER FICHIER" button is
+ * clicked : this is required because Dolibarr's actions_linkedfiles.inc.php only
+ * processes the upload when the "sendit" parameter is present (which a plain
+ * form submit would not send).
+ *
+ * @memberof Saturne_Framework_Document
+ *
+ * @since   1.7.0
+ * @version 1.7.0
+ *
+ * @param  {Object} event Drop event.
+ * @return {void}
+ */
+window.saturne.document.onDrop = function(event) {
+  if (!window.saturne.document.isFileDrag(event)) {
+    return;
+  }
+  let zone = window.saturne.document.getUploadZone();
+  if (!zone.length) {
+    return;
+  }
+  event.preventDefault();
+  zone.removeClass('attacharea-dragover');
+
+  let fileInput = zone.find('input[type="file"][name^="userfile"]')[0];
+  let sendButton = zone.find('input[type="submit"][name="sendit"]')[0];
+  // Upload disabled (MAIN_UPLOAD_DOC off or no write permission) : do nothing
+  if (!fileInput || fileInput.disabled || !sendButton) {
+    return;
+  }
+
+  let files = event.originalEvent.dataTransfer.files;
+  if (!files || files.length === 0) {
+    return;
+  }
+
+  let dataTransfer = new window.DataTransfer();
+  for (let i = 0; i < files.length; i++) {
+    dataTransfer.items.add(files[i]);
+  }
+  fileInput.files = dataTransfer.files;
+
+  // Visual feedback while the file is being sent (the page reloads on success)
+  window.saturne.loader.display(zone);
+
+  sendButton.click();
 };

--- a/langs/en_US/saturne.lang
+++ b/langs/en_US/saturne.lang
@@ -271,3 +271,6 @@ ResetColumns = Reset
 # List filter display mode
 SwitchFilterToPanel = Filters in panel
 SwitchFilterToClassic = Inline filters
+
+# Attached files drag & drop
+DropFilesHere = Drag and drop your files here

--- a/langs/fr_FR/saturne.lang
+++ b/langs/fr_FR/saturne.lang
@@ -290,3 +290,6 @@ ResetColumns = Réinitialiser
 # List filter display mode
 SwitchFilterToPanel = Filtres en volet
 SwitchFilterToClassic = Filtres en ligne
+
+# Attached files drag & drop
+DropFilesHere = Glissez-déposez vos fichiers ici

--- a/view/saturne_document.php
+++ b/view/saturne_document.php
@@ -169,6 +169,9 @@ if ($id > 0 || !empty($ref)) {
 
     $relativepathwithnofile = $object->element . '/' . dol_sanitizeFileName($object->ref) . '/';
 
+    // Drag & drop hint label, injected into the upload zone by saturne.document.js
+    print '<span id="saturne-drop-files-label" class="hidden">' . dol_escape_htmltag($langs->trans('DropFilesHere')) . '</span>';
+
     require_once DOL_DOCUMENT_ROOT . '/core/tpl/document_actions_post_headers.tpl.php';
 }
 


### PR DESCRIPTION
## Contexte

Closes #1393
Lié à Evarisk/digiquali#2425

L'onglet **Fichiers joints** (vue générique `view/saturne_document.php`, utilisée par tous les modules) n'avait pas de **glissé-déposé** : depuis Dolibarr 23, `FormFile::form_attach_new_file()` ne génère plus l'ancien widget d'upload AJAX (blueimp) qui le fournissait, et ses assets frontend ont été retirés. Seul le formulaire classique (`input[type=file]` + bouton) restait.

## Solution

- Toute la zone de l'onglet devient une **zone de dépôt visible** (boîte en pointillés + libellé « Glissez-déposez vos fichiers ici », surbrillance bleue au survol).
- Au drop, les fichiers sont injectés dans l'input `userfile[]` existant puis le bouton **`sendit`** est cliqué — requis car `actions_linkedfiles.inc.php` ne traite l'upload que si le paramètre `sendit` est présent (un simple submit ne l'enverrait pas). Spinner pendant l'envoi.
- Rien ne se passe si l'upload est désactivé (`MAIN_UPLOAD_DOC` off ou pas de droit d'écriture). Multi-fichiers supporté.

Aucun backend ajouté (réutilise le traitement Dolibarr standard).

## Fichiers

| Fichier | Rôle |
|---|---|
| `js/modules/document.js` | Logique drag & drop + injection du libellé |
| `css/scss/style.scss` | Style de la zone de dépôt |
| `view/saturne_document.php` | Expose le libellé traduit |
| `langs/fr_FR/saturne.lang`, `langs/en_US/saturne.lang` | Clé `DropFilesHere` |

`.min.js`/`.min.css` volontairement non committés (build via CI `build-assets`).

## Impact

Bénéficie à **tous les modules** Saturne. Résout Evarisk/digiquali#2425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
