### PR TITLE
#1396 [Menu] fix: initialize $riskType in saturne_display_recurse_tree (PHP 8 warning)

### DIFF
--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -139,6 +139,8 @@ function saturne_display_recurse_tree(array $moreParams, array $objectElementTre
 {
     global $conf, $langs, $user;
 
+    $riskType = GETPOSTISSET('risk_type') && !empty(GETPOST('risk_type')) ? GETPOST('risk_type') : 'risk';
+
     if (!$user->hasRight($moreParams['moduleNameLowerCase'], $moreParams['objectElement'], 'read')) {
         print $langs->transnoentities('YouDontHaveTheRightOnObject', $langs->trans(dol_ucfirst($moreParams['objectElement'])));
         return;

--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -12223,12 +12223,6 @@ parameters:
 			path: lib/saturne_functions.lib.php
 
 		-
-			message: '#^Undefined variable\: \$riskType$#'
-			identifier: variable.undefined
-			count: 1
-			path: lib/saturne_functions.lib.php
-
-		-
 			message: '#^Variable \$head might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1


### PR DESCRIPTION
## Contexte

Fix **PHP 8**. La variable `$riskType` était lue sans avoir été définie dans le scope de `saturne_display_recurse_tree()`, ce qui générait `Warning: Undefined variable $riskType` lors du rendu du menu de navigation secondaire (reproduit sur une fiche DigiQuali).

La fonction a été généralisée depuis `digiriskdolibarr_function.lib.php` où `$riskType` était initialisé avant la boucle ; cette initialisation avait été perdue (commentaire `//@todo gérer le lien`).

## Changements

- Initialisation de `$riskType` dans `saturne_display_recurse_tree()`, en reprenant la convention DigiRisk :
  `$riskType = GETPOSTISSET('risk_type') && !empty(GETPOST('risk_type')) ? GETPOST('risk_type') : 'risk';`
- Suppression de l'entrée PHPStan baseline désormais obsolète (`Undefined variable: $riskType`).

## Tests

- `php -l lib/saturne_functions.lib.php` → aucune erreur de syntaxe.
- Vérification runtime : `$riskType` vaut `'risk'` par défaut (param GET absent) et le lien généré reste valide, sans aucun warning.

## Fichiers modifiés

- `lib/saturne_functions.lib.php`
- `phpstan.baseline.neon`

## Issue

Closes #1396
