### PR TITLE
[Document] fix: keep company logo aspect ratio in ODT documents

### DIFF
--- a/core/modules/saturne/modules_saturne.php
+++ b/core/modules/saturne/modules_saturne.php
@@ -545,7 +545,20 @@ class SaturneDocumentModel extends CommonDocGenerator
                 if (preg_match('/photo|picto/', $key) || preg_match('/logo$/', $key)) {
                     // Image.
                     if (file_exists($val)) {
-                        $listLines->setImage($key, $val);
+                        if (preg_match('/logo$/', $key)) {
+                            // Fit the logo into a bounding box while keeping its aspect ratio,
+                            // otherwise a wide company logo is flattened in the document header.
+                            $ratio     = 1;
+                            $imageSize = getimagesize($val);
+                            if (!empty($imageSize[0]) && !empty($imageSize[1])) {
+                                $maxWidth  = 128; // px, keeps the previous _mini logo footprint
+                                $maxHeight = 72;  // px (16/9 bounding box)
+                                $ratio     = min($maxWidth / $imageSize[0], $maxHeight / $imageSize[1], 1);
+                            }
+                            $listLines->setImage($key, $val, $ratio);
+                        } else {
+                            $listLines->setImage($key, $val);
+                        }
                     } else if (dol_strlen($val) > 0){
 						if ($key == 'mycompany_logo') {
 							$listLines->setVars($key, $outputLangs->transnoentities('ErrorNoSocietyLogo'), true, 'UTF-8');
@@ -897,7 +910,7 @@ class SaturneDocumentModel extends CommonDocGenerator
         $substitutionArray          = getCommonSubstitutionArray($outputLangs, 0, null, $object);
         $arrayObjectFromProperties  = $this->get_substitutionarray_each_var_object($object, $outputLangs);
         $arraySoc                   = $this->get_substitutionarray_mysoc($mysoc, $outputLangs);
-        $arraySoc['mycompany_logo'] = preg_replace('/_small/', '_mini', $arraySoc['mycompany_logo']);
+        // Keep the sharper _small thumbnail; its size is bounded while preserving the aspect ratio in setTmpArrayVars().
 
         $tmpArray = array_merge($substitutionArray, $arrayObjectFromProperties, $arraySoc, $moreParam['tmparray']);
         if (isModEnabled('multicompany')) {


### PR DESCRIPTION
## Contexte

Refs Evarisk/dolimeet#803 (« logo écrasé feuille de présence »)

Le logo société était inséré dans les documents ODT via `setTmpArrayVars()` :
- rétrogradé en miniature **`_mini`** (≤128×72 px, basse résolution) à `modules_saturne.php:909` ;
- puis passé à `setImage($key, $val)` **sans boîte englobante**.

Résultat : un logo large (ex. ellipse) est rendu en **fine bande aplatie et pixelisée** dans l'en-tête (cf. la feuille de présence DoliMeet). Contrairement aux **signatures** (gérées juste en dessous), le logo n'avait aucune maîtrise de taille/ratio.

## Correctif

Dans `SaturneDocumentModel` (`core/modules/saturne/modules_saturne.php`) :

1. **Logo uniquement** : insertion dans une **boîte englobante 128×72 px** (l'empreinte de l'ancien `_mini`) en **conservant le ratio**, via le 3ᵉ paramètre `$ratio` de `setImage()` (déjà supporté par `Odf` et `Segment`). Les clés `photo`/`picto` gardent leur comportement.
2. Suppression de la rétrogradation `_small` → `_mini` : on garde la miniature **`_small`** (plus nette), la taille étant désormais bornée à l'insertion.

Effet : logo **net** et **jamais déformé**, à empreinte identique à l'existant → aucun décalage de mise en page pour les logos déjà corrects.

## Portée

Code **partagé Saturne** → s'applique à tous les documents ODT de tous les modules (DoliMeet, Digirisk, DigiQuali…). Changement volontairement minimal et iso-empreinte. Aucun asset `.min` impacté (PHP pur).

## Test

1. Société avec un logo non carré (ex. large) dans *Configuration > Société*.
2. Générer une feuille de présence DoliMeet (ou tout autre ODT avec `{mycompany_logo}`).
3. Vérifier que le logo est net et **à son ratio d'origine** (plus aplati).