### PR TITLE
#1401 [Task] fix: php8 undefined property fk_task in fetchAllTimeSpentAllUser

### DIFF
--- a/class/task/saturnetask.class.php
+++ b/class/task/saturnetask.class.php
@@ -361,6 +361,7 @@ class SaturneTask extends Task
                 $newobj->project_ref   = $obj->project_ref;
                 $newobj->project_label = $obj->project_label;
 
+                $newobj->fk_task    = $obj->task_id;
                 $newobj->task_ref   = $obj->task_ref;
                 $newobj->task_label = $obj->task_label;
 


### PR DESCRIPTION
## Changements

Correction d'un warning de compatibilité PHP 8 (`Undefined property: stdClass::$fk_task`) dans `fetchAllTimeSpentAllUser()`.

La méthode construit un `stdClass` par ligne et recopie les champs sélectionnés, mais ne recopiait jamais l'id de tâche. Lorsqu'elle est appelée avec `$sortedByTasks > 0`, le regroupement `$timeSpentSortedByTasks[$timeSpent->fk_task]` lisait une propriété inexistante (et retombait sur une clé vide).

Ajout de la recopie de l'id de tâche dans la boucle (alias SQL `task_id` = `pt.rowid`) :

```php
$newobj->fk_task = $obj->task_id;
```

## Fichiers modifiés

- `class/task/saturnetask.class.php`

## Issue

#1401
