### PR TITLE
#1403 [Doliopi] rework: rename DoliMeet references to Doliopi

### DIFF
--- a/class/actions_saturne.class.php
+++ b/class/actions_saturne.class.php
@@ -434,7 +434,7 @@ class ActionsSaturne
             $elementId = GETPOST('element_id');
             $type      = GETPOST('type');
 
-            // Temporary exclude DoliMeet and native Dolibarr objects
+            // Temporary exclude Doliopi and native Dolibarr objects
             if ($type == 'meeting' || $type == 'audit' || $type == 'trainingsession' || !empty(saturne_get_objects_metadata($type))) {
                 return 0;
             }

--- a/core/modules/modSaturne.class.php
+++ b/core/modules/modSaturne.class.php
@@ -136,7 +136,7 @@ class modSaturne extends DolibarrModules
         // Dependencies
         $modulesList = [
             'DigiQuali'        => 'digiquali',
-            'DoliMeet'         => 'dolimeet',
+            'Doliopi'          => 'doliopi',
             'DoliCar'          => 'dolicar',
             'ReedCRM'          => 'reedcrm',
             'DoliSIRH'         => 'dolisirh',

--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -748,10 +748,10 @@ function saturne_create_category(string $label = '', string $type = '', int $fkP
             'preventionplan'  => ['id' => 436302002, 'obj_class' => 'PreventionPlan', 'obj_table' => 'digiriskdolibarr_preventionplan'],
             'firepermit'      => ['id' => 436302003, 'obj_class' => 'FirePermit', 'obj_table' => 'digiriskdolibarr_firepermit'],
             'risk'            => ['id' => 436302004, 'obj_class' => 'Risk', 'obj_table' => 'digiriskdolibarr_risk'],
-            'meeting'         => ['id' => 436304001, 'obj_class' => 'Meeting', 'obj_table' => 'dolimeet_session'],
-            'trainingsession' => ['id' => 436304002, 'obj_class' => 'Trainingsession', 'obj_table' => 'dolimeet_session'],
-            'audit'           => ['id' => 436304003, 'obj_class' => 'Audit', 'obj_table' => 'dolimeet_session'],
-            'session'         => ['id' => 436304004, 'obj_class' => 'Session', 'obj_table' => 'dolimeet_session']
+            'meeting'         => ['id' => 436304001, 'obj_class' => 'Meeting', 'obj_table' => 'doliopi_session'],
+            'trainingsession' => ['id' => 436304002, 'obj_class' => 'Trainingsession', 'obj_table' => 'doliopi_session'],
+            'audit'           => ['id' => 436304003, 'obj_class' => 'Audit', 'obj_table' => 'doliopi_session'],
+            'session'         => ['id' => 436304004, 'obj_class' => 'Session', 'obj_table' => 'doliopi_session']
         ];
         if (isset($customTags[$type])) {
             $category->MAP_ID[$type]        = $customTags[$type]['id'];


### PR DESCRIPTION
## Contexte

Adaptation de Saturne au renommage du module `dolimeet` en `doliopi` (Evarisk/dolimeet#860, PR Evarisk/dolimeet#861).

## Changements

- `lib/saturne_functions.lib.php` : `obj_table` des types `meeting` / `trainingsession` / `audit` / `session` → `doliopi_session`. **Critique** : table interrogée par les fetch d'objets de session.
- `core/modules/modSaturne.class.php` : map des modules `'DoliMeet' => 'dolimeet'` → `'Doliopi' => 'doliopi'`.
- `class/actions_saturne.class.php` : commentaire mis à jour (cosmétique).

## Dépendance

À fusionner avec la PR de renommage : Evarisk/dolimeet#861. Sans ce changement, les fetch de sessions du module renommé échouent.

## Issue

Evarisk/Saturne#1403
