### PR TITLE
#2442 [Media] feat: delete a photo from the gallery photo editor

### DIFF
--- a/core/tpl/medias/photo_editor_modal.tpl.php
+++ b/core/tpl/medias/photo_editor_modal.tpl.php
@@ -44,13 +44,29 @@
             <button type="button" id="saturne-btn-delete-photo" class="saturne-photo-editor-header__delete" style="display: none;" title="<?php echo dol_escape_htmltag($langs->trans('DeletePhoto')); ?>" data-confirm="<?php echo dol_escape_htmltag($langs->trans('DeletePhotoConfirmation')); ?>">
                 <i class="fas fa-trash"></i>
             </button>
-            <div class="saturne-photo-editor-header__settings" title="<?php echo $langs->trans('Settings'); ?>">
-                <i class="fas fa-ellipsis-v"></i>
-                <select id="saturne-photo-size-select">
-                    <option value="hd" selected>HD (720p)</option>
-                    <option value="fullhd">Full HD (1080p)</option>
-                    <option value="full">Original (FULL)</option>
-                </select>
+            <div class="saturne-photo-editor-header__settings">
+                <i class="fas fa-ellipsis-v" id="saturne-photo-settings-toggle" title="<?php echo $langs->trans('Settings'); ?>"></i>
+                <div class="saturne-photo-editor-settings-menu" id="saturne-photo-settings-menu" style="display: none;">
+                    <div class="saturne-settings-section">
+                        <span class="saturne-settings-label"><?php echo $langs->trans('Quality'); ?></span>
+                        <select id="saturne-photo-size-select">
+                            <option value="hd" selected>HD (720p)</option>
+                            <option value="fullhd">Full HD (1080p)</option>
+                            <option value="full">Original (FULL)</option>
+                        </select>
+                    </div>
+                    <div class="saturne-settings-section">
+                        <span class="saturne-settings-label"><?php echo $langs->trans('AvailableTools'); ?></span>
+                        <?php
+                        $editorTools = ['crop' => 'Crop', 'rotate' => 'Rotate', 'pencil' => 'Draw', 'text' => 'Text', 'arrow' => 'Arrow', 'rect' => 'Frame', 'blur' => 'Blur', 'sequence' => 'Sequence'];
+                        foreach ($editorTools as $toolKey => $toolLabel) : ?>
+                            <label class="saturne-settings-tool">
+                                <input type="checkbox" class="saturne-editor-tool-toggle" data-tool="<?php echo dol_escape_htmltag($toolKey); ?>" checked>
+                                <span><?php echo $langs->trans($toolLabel); ?></span>
+                            </label>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
             </div>
         </div>
 

--- a/core/tpl/medias/photo_editor_modal.tpl.php
+++ b/core/tpl/medias/photo_editor_modal.tpl.php
@@ -41,6 +41,9 @@
                     <span id="saturne-photo-resolution-display"></span>
                 </h3>
             </div>
+            <button type="button" id="saturne-btn-delete-photo" class="saturne-photo-editor-header__delete" style="display: none;" title="<?php echo dol_escape_htmltag($langs->trans('DeletePhoto')); ?>" data-confirm="<?php echo dol_escape_htmltag($langs->trans('DeletePhotoConfirmation')); ?>">
+                <i class="fas fa-trash"></i>
+            </button>
             <div class="saturne-photo-editor-header__settings" title="<?php echo $langs->trans('Settings'); ?>">
                 <i class="fas fa-ellipsis-v"></i>
                 <select id="saturne-photo-size-select">

--- a/css/scss/modules/medias/_photo-editor.scss
+++ b/css/scss/modules/medias/_photo-editor.scss
@@ -93,16 +93,59 @@
         cursor: pointer;
         padding: 0 5px;
 
-        #saturne-photo-size-select {
+        .saturne-photo-editor-settings-menu {
             position: absolute;
-            top: 0;
+            top: 100%;
             right: 0;
-            width: 30px;
-            height: 100%;
-            opacity: 0;
+            z-index: 30;
+            min-width: 190px;
+            margin-top: 6px;
+            padding: 10px 12px;
+            background: #fff;
+            border: 1px solid #e2e8f0;
+            border-radius: 8px;
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+            font-size: 13px;
+            color: #333;
+            cursor: default;
+            text-align: left;
+        }
+
+        .saturne-settings-section + .saturne-settings-section {
+            margin-top: 10px;
+            padding-top: 10px;
+            border-top: 1px solid #eef0f3;
+        }
+
+        .saturne-settings-label {
+            display: block;
+            font-size: 11px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+            color: #8a93a0;
+            margin-bottom: 6px;
+        }
+
+        #saturne-photo-size-select {
+            width: 100%;
+            padding: 4px 6px;
+            border: 1px solid #d4d8de;
+            border-radius: 6px;
+            font-size: 13px;
+        }
+
+        .saturne-settings-tool {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 3px 0;
+            font-size: 13px;
             cursor: pointer;
-            appearance: none;
-            -webkit-appearance: none;
+
+            input {
+                cursor: pointer;
+            }
         }
     }
 }

--- a/css/scss/modules/medias/_photo-editor.scss
+++ b/css/scss/modules/medias/_photo-editor.scss
@@ -86,6 +86,33 @@
         }
     }
 
+    &__delete {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 34px;
+        height: 34px;
+        margin: 0 4px 0 auto;
+        padding: 0;
+        background: none;
+        border: none;
+        border-radius: 8px;
+        color: #e74c3c;
+        font-size: 17px;
+        line-height: 1;
+        cursor: pointer;
+        transition: background-color 0.15s, color 0.15s, transform 0.1s;
+
+        &:hover {
+            background: rgba(231, 76, 60, 0.12);
+            color: #c0392b;
+        }
+
+        &:active {
+            transform: scale(0.92);
+        }
+    }
+
     &__settings {
         position: relative;
         color: #94a3b8;

--- a/js/modules/mediaBlock.js
+++ b/js/modules/mediaBlock.js
@@ -134,7 +134,15 @@ window.saturne.mediaBlock.onGalleryClick = function() {
     var filePath         = decodeURIComponent(urlParams.get('file') || '');
     var originalFilename = filePath.split('/').pop() || null;
     window.saturne.mediaBlock.uploadBlob(blob, module, subdir, block, originalFilename);
-  }, 0);
+  }, 0, function(deletedUrl) {
+    // Delete callback: resolve the filename from the document.php URL and ask the server to remove it
+    var delParams   = new URLSearchParams((deletedUrl || '').split('?')[1] || '');
+    var delFilePath = decodeURIComponent(delParams.get('file') || '');
+    var delFilename = delFilePath.split('/').pop() || null;
+    if (delFilename) {
+      window.saturne.mediaBlock.deletePhoto(delFilename, module, subdir, block);
+    }
+  });
 };
 
 /**
@@ -181,6 +189,50 @@ window.saturne.mediaBlock.uploadBlob = function(blob, module, subdir, block, ori
         $srcBlock = $doc.find('.linked-medias').first();
       }
       var $gallery   = $srcBlock.find('.saturne-media-gallery');
+      if ($gallery.length && block && block.length) {
+        block.find('.saturne-media-gallery').replaceWith($gallery);
+      }
+    }
+  });
+};
+
+/**
+ * Delete a photo from the server via AJAX and refresh the gallery section in place.
+ *
+ * @memberof Saturne_MediaBlock
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @param   {string} filename Name of the photo file to delete
+ * @param   {string} module   Module name
+ * @param   {string} subdir   Sub-directory
+ * @param   {jQuery} block    The .linked-medias block element
+ * @returns {void}
+ */
+window.saturne.mediaBlock.deletePhoto = function(filename, module, subdir, block) {
+  var token          = window.saturne.toolbox.getToken();
+  var querySeparator = window.saturne.toolbox.getQuerySeparator(document.URL);
+  var formData       = new FormData();
+
+  formData.append('filename', filename);
+  formData.append('module_name', module);
+  formData.append('sub_dir', subdir);
+
+  $.ajax({
+    url         : document.URL + querySeparator + 'action=deletePhoto&token=' + token,
+    type        : 'POST',
+    data        : formData,
+    processData : false,
+    contentType : false,
+    complete    : function(resp) {
+      var $doc      = $('<div>').html(resp.responseText);
+      var blockId   = block && block.attr('id');
+      var $srcBlock = blockId ? $doc.find('#' + blockId) : $();
+      if (!$srcBlock.length) {
+        $srcBlock = $doc.find('.linked-medias').first();
+      }
+      var $gallery = $srcBlock.find('.saturne-media-gallery');
       if ($gallery.length && block && block.length) {
         block.find('.saturne-media-gallery').replaceWith($gallery);
       }

--- a/js/modules/photoEditor.js
+++ b/js/modules/photoEditor.js
@@ -56,6 +56,56 @@ window.saturne.photoEditor._urls         = [];
 window.saturne.photoEditor._currentIndex = 0;
 
 /**
+ * Resolve the DOM element of a given editor tool ('pencil' is wrapped in its own container).
+ *
+ * @param   {string} tool data-mode of the tool
+ * @returns {Element|null}
+ */
+window.saturne.photoEditor._toolElement = function(tool) {
+  if (tool === 'pencil') {
+    return document.getElementById('saturne-pencil-tool-container');
+  }
+  return document.querySelector('.saturne-tool-btn[data-mode="' + tool + '"]');
+};
+
+/**
+ * Read the list of tools the user chose to hide (persisted per browser).
+ *
+ * @returns {Array}
+ */
+window.saturne.photoEditor._getHiddenTools = function() {
+  try {
+    return JSON.parse(window.localStorage.getItem('saturne_photo_editor_hidden_tools') || '[]') || [];
+  } catch (e) {
+    return [];
+  }
+};
+
+/**
+ * Apply the persisted tool visibility: hide disabled tools, sync the settings checkboxes,
+ * and turn drawing off when the pencil tool is disabled.
+ *
+ * @returns {void}
+ */
+window.saturne.photoEditor._applyToolVisibility = function() {
+  var hidden  = window.saturne.photoEditor._getHiddenTools();
+  var toggles = document.querySelectorAll('.saturne-editor-tool-toggle');
+  for (var i = 0; i < toggles.length; i++) {
+    var tool     = toggles[i].getAttribute('data-tool');
+    var isHidden = hidden.indexOf(tool) !== -1;
+    toggles[i].checked = !isHidden;
+    var el = window.saturne.photoEditor._toolElement(tool);
+    if (el) {
+      el.style.display = isHidden ? 'none' : '';
+    }
+  }
+  // Disabling the pencil must actually stop drawing, not only hide the button
+  if (hidden.indexOf('pencil') !== -1 && window.saturne.photoEditor._currentMode === 'pencil') {
+    window.saturne.photoEditor._currentMode = null;
+  }
+};
+
+/**
  * Photo editor init
  *
  * @memberof Saturne_PhotoEditor
@@ -221,6 +271,44 @@ window.saturne.photoEditor.event = function() {
     });
   }
 
+  // Settings menu (the … vertical button): toggle the panel + per-tool show/hide (persisted)
+  var settingsToggle = document.getElementById('saturne-photo-settings-toggle');
+  var settingsMenu   = document.getElementById('saturne-photo-settings-menu');
+  if (settingsToggle && settingsMenu) {
+    settingsToggle.addEventListener('click', function(e) {
+      e.stopPropagation();
+      settingsMenu.style.display = (settingsMenu.style.display === 'none') ? 'block' : 'none';
+    });
+    settingsMenu.addEventListener('click', function(e) {
+      e.stopPropagation();
+    });
+    document.addEventListener('click', function() {
+      settingsMenu.style.display = 'none';
+    });
+  }
+
+  var toolToggles = document.querySelectorAll('.saturne-editor-tool-toggle');
+  for (var ti = 0; ti < toolToggles.length; ti++) {
+    toolToggles[ti].addEventListener('change', function() {
+      var pe     = window.saturne.photoEditor;
+      var hidden = pe._getHiddenTools();
+      var tool   = this.getAttribute('data-tool');
+      var idx    = hidden.indexOf(tool);
+      if (this.checked && idx !== -1) {
+        hidden.splice(idx, 1);
+      } else if (!this.checked && idx === -1) {
+        hidden.push(tool);
+      }
+      try {
+        window.localStorage.setItem('saturne_photo_editor_hidden_tools', JSON.stringify(hidden));
+      } catch (e) {
+        // localStorage unavailable — keep the in-session toggle only
+      }
+      pe._applyToolVisibility();
+    });
+  }
+  window.saturne.photoEditor._applyToolVisibility();
+
   // Close on overlay click
   modal.addEventListener('click', function(e) {
     if (e.target === modal) {
@@ -266,6 +354,9 @@ window.saturne.photoEditor.open = function(urlOrUrls, onSave, startIndex, onDele
   if (btnDeleteEl) {
     btnDeleteEl.style.display = (typeof pe._onDelete === 'function') ? 'flex' : 'none';
   }
+
+  // Re-apply the user's tool visibility preferences
+  pe._applyToolVisibility();
 
   var btnPrevEl = document.getElementById('saturne-btn-prev-photo');
   var btnNextEl = document.getElementById('saturne-btn-next-photo');

--- a/js/modules/photoEditor.js
+++ b/js/modules/photoEditor.js
@@ -51,6 +51,7 @@ window.saturne.photoEditor._startCX      = 0;
 window.saturne.photoEditor._startCY      = 0;
 window.saturne.photoEditor._seqCounter   = 1;
 window.saturne.photoEditor._onSave       = null;
+window.saturne.photoEditor._onDelete     = null;
 window.saturne.photoEditor._urls         = [];
 window.saturne.photoEditor._currentIndex = 0;
 
@@ -200,6 +201,26 @@ window.saturne.photoEditor.event = function() {
     }
   });
 
+  // Delete — remove the currently displayed photo (only when a delete callback was provided)
+  var btnDelete = document.getElementById('saturne-btn-delete-photo');
+  if (btnDelete) {
+    btnDelete.addEventListener('click', function() {
+      var pe = window.saturne.photoEditor;
+      if (typeof pe._onDelete !== 'function' || !pe._urls.length) {
+        return;
+      }
+      var confirmMsg = btnDelete.getAttribute('data-confirm');
+      if (confirmMsg && !window.confirm(confirmMsg)) {
+        return;
+      }
+      var url      = pe._urls[pe._currentIndex];
+      var onDelete = pe._onDelete;
+      // Close first so the gallery refresh from the callback is not hidden behind the editor
+      pe._close();
+      onDelete(url, pe._currentIndex);
+    });
+  }
+
   // Close on overlay click
   modal.addEventListener('click', function(e) {
     if (e.target === modal) {
@@ -227,7 +248,7 @@ window.saturne.photoEditor.event = function() {
  * @param   {Function} onSave Callback receiving a Blob on validate
  * @returns {void}
  */
-window.saturne.photoEditor.open = function(urlOrUrls, onSave, startIndex) {
+window.saturne.photoEditor.open = function(urlOrUrls, onSave, startIndex, onDelete) {
   var modal = window.saturne.photoEditor._modal;
   if (!modal) {
     return;
@@ -235,9 +256,16 @@ window.saturne.photoEditor.open = function(urlOrUrls, onSave, startIndex) {
 
   var pe             = window.saturne.photoEditor;
   pe._onSave         = onSave || null;
+  pe._onDelete       = onDelete || null;
   pe._historyStack   = [];
   pe._urls           = Array.isArray(urlOrUrls) ? urlOrUrls : [urlOrUrls];
   pe._currentIndex   = (typeof startIndex === 'number') ? startIndex : 0;
+
+  // The delete button is only relevant when the caller wired a delete callback
+  var btnDeleteEl = document.getElementById('saturne-btn-delete-photo');
+  if (btnDeleteEl) {
+    btnDeleteEl.style.display = (typeof pe._onDelete === 'function') ? 'flex' : 'none';
+  }
 
   var btnPrevEl = document.getElementById('saturne-btn-prev-photo');
   var btnNextEl = document.getElementById('saturne-btn-next-photo');

--- a/langs/en_US/medias.lang
+++ b/langs/en_US/medias.lang
@@ -29,6 +29,8 @@ PhotoNotSent              = The photo was not sent correctly
 ConfirmUnlinkMedia        = Are you sure you want to detach the selected media ?
 AddPhotoFromComputer      = Add a photo from device gallery
 AddPhotoFromMediaGallery  = Add a photo from media gallery
+DeletePhoto               = Delete photo
+DeletePhotoConfirmation   = Delete this photo?
 
 # Config page
 MediaMaxWidthMini                    = Minimum media width

--- a/langs/en_US/medias.lang
+++ b/langs/en_US/medias.lang
@@ -31,6 +31,8 @@ AddPhotoFromComputer      = Add a photo from device gallery
 AddPhotoFromMediaGallery  = Add a photo from media gallery
 DeletePhoto               = Delete photo
 DeletePhotoConfirmation   = Delete this photo?
+AvailableTools            = Available tools
+Quality                   = Quality
 
 # Config page
 MediaMaxWidthMini                    = Minimum media width

--- a/langs/fr_FR/medias.lang
+++ b/langs/fr_FR/medias.lang
@@ -32,6 +32,8 @@ AddPhotoFromComputer      = Ajouter une photo depuis la galerie de l'appareil
 AddPhotoFromMediaGallery  = Ajouter une photo depuis la galerie des médias
 DeletePhoto               = Supprimer la photo
 DeletePhotoConfirmation   = Supprimer cette photo ?
+AvailableTools            = Outils disponibles
+Quality                   = Qualité
 
 # Config page - Page d'administration
 MediaMaxWidthMini                    = Largeur du média mini

--- a/langs/fr_FR/medias.lang
+++ b/langs/fr_FR/medias.lang
@@ -30,6 +30,8 @@ MediaData                 = Configuration des médias
 ConfirmUnlinkMedia        = Êtes vous sur de vouloir détacher le media sélectionné ?
 AddPhotoFromComputer      = Ajouter une photo depuis la galerie de l'appareil
 AddPhotoFromMediaGallery  = Ajouter une photo depuis la galerie des médias
+DeletePhoto               = Supprimer la photo
+DeletePhotoConfirmation   = Supprimer cette photo ?
 
 # Config page - Page d'administration
 MediaMaxWidthMini                    = Largeur du média mini


### PR DESCRIPTION
Prérequis pour Evarisk/Digiquali#2442 (suppression des photos d'un contrôle).

Le bloc média moderne (`saturne_render_media_block`) ne permettait pas de **supprimer** une photo : la galerie n'ouvrait que l'éditeur (annotation).

## Changements
- Bouton **corbeille** dans l'en-tête de l'éditeur photo (`photo_editor_modal.tpl.php`), affiché uniquement quand l'appelant fournit un callback de suppression.
- `photoEditor.open(urls, onSave, startIndex, onDelete)` : nouveau 4e paramètre `onDelete` ; le bouton supprime la photo courante (avec confirmation) puis ferme l'éditeur.
- `mediaBlock.js` : `onGalleryClick` câble le callback de suppression et nouvelle fonction `deletePhoto()` qui poste `action=deletePhoto` et rafraîchit la galerie en place (même schéma que `uploadBlob`).
- Traductions `DeletePhoto` / `DeletePhotoConfirmation` (fr_FR + en_US).

Le module hôte (DigiQuali) gère `action=deletePhoto` côté serveur. `.min` non commités (build CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)