### PR TITLE
#1408 [Documents] fix: do not store scandir for pdf models in admin toggle

### DIFF
--- a/core/tpl/admin/object/object_document_model_view.tpl.php
+++ b/core/tpl/admin/object/object_document_model_view.tpl.php
@@ -68,7 +68,11 @@ if (is_array($filelist) && !empty($filelist)) {
                     print img_picto($langs->trans('Enabled'), 'switch_on');
                     print '</a>';
                 } else {
-                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=set&model_name=' . $name . '&const=' . $module->scandir . '&label=' . urlencode($module->name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
+                    // PDF models do not scan a template directory: never store scandir as
+                    // description, otherwise saturne_get_list_of_models() would list one entry
+                    // per file found in that directory instead of a single model entry.
+                    $modelScandir = ($module->type == 'pdf') ? '' : $module->scandir;
+                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=set&model_name=' . $name . '&const=' . $modelScandir . '&label=' . urlencode($module->name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
                     print img_picto($langs->trans('Disabled'), 'switch_off');
                     print '</a>';
                 }


### PR DESCRIPTION
## Changements

- Dans le lien d'activation du tpl admin documents, ne plus passer `scandir` comme `description` pour les modèles **PDF** :
  ```php
  $modelScandir = ($module->type == 'pdf') ? '' : $module->scandir;
  ```

## Pourquoi

`saturne_get_list_of_models()` interprète une `description` non vide comme le nom d'une constante pointant vers un dossier à scanner, et ajoute une entrée par fichier trouvé. Or `SaturneDocumentModel` initialise `scandir` au dossier des templates ODT pour tous les modèles, PDF compris. Résultat : activer un PDF via le switch admin remplissait le sélecteur de génération de doublons (un par fichier ODT). Un modèle PDF ne scanne aucun dossier de templates → il ne doit jamais porter de `scandir`.

## Fichiers modifiés

- `core/tpl/admin/object/object_document_model_view.tpl.php`

## Issue

#1408
