### PR TITLE
#1410 [Filtre] remove: include/exclude eye toggle on saturne lists

### DIFF
--- a/core/tpl/list/objectfields_list_build_sql_select.tpl.php
+++ b/core/tpl/list/objectfields_list_build_sql_select.tpl.php
@@ -156,7 +156,6 @@ foreach ($search as $key => $val) {
 
 
         $mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
-        $isExclude   = (GETPOST('search_' . $key . '_mode', 'alpha') === 'exc');
         if (isset($object->fields[$key]['type']) && ((strpos($object->fields[$key]['type'], 'integer:') === 0) || (strpos($object->fields[$key]['type'], 'sellist:') === 0) || !empty($object->fields[$key]['arrayofkeyval']))) {
             if ($val == '-1' || ($val === '0' && (empty($object->fields[$key]['arrayofkeyval']) || !array_key_exists('0', $object->fields[$key]['arrayofkeyval'])))) {
                 $val = '';
@@ -175,26 +174,10 @@ foreach ($search as $key => $val) {
         }
         if (empty($object->fields[$key]['searchmulti'])) {
             if (!is_array($val) && $val != '') {
-                if ($isExclude) {
-                    if ($mode_search === 2) {
-                        $sql .= ' AND t.' . $db->escape($key) . ' != ' . (int) $val;
-                    } elseif ($mode_search === 3) {
-                        $sql .= " AND t." . $db->escape($key) . " != '" . $db->escape($val) . "'";
-                    } else {
-                        $sql .= ' AND t.' . $db->escape($key) . ' != ' . (int) $val;
-                    }
-                } else {
-                    $sql .= natural_search('t.' . $db->escape($key), $val, (($key == 'status') ? 2 : $mode_search));
-                }
+                $sql .= natural_search('t.' . $db->escape($key), $val, (($key == 'status') ? 2 : $mode_search));
             }
         } elseif (is_array($val) && !empty($val)) {
-            if ($isExclude && $mode_search === 2) {
-                $sql .= ' AND t.' . $db->escape($key) . ' NOT IN (' . implode(',', array_map('intval', $val)) . ')';
-            } elseif ($isExclude && $mode_search === 3) {
-                $sql .= ' AND t.' . $db->escape($key) . " NOT IN (" . implode(',', array_map(function ($v) use ($db) { return "'" . $db->escape($v) . "'"; }, $val)) . ")";
-            } else {
-                $sql .= natural_search('t.' . $db->escape($key), implode(',', $val), (($key == 'status') ? 2 : $mode_search));
-            }
+            $sql .= natural_search('t.' . $db->escape($key), implode(',', $val), (($key == 'status') ? 2 : $mode_search));
         }
     } elseif (preg_match('/(_dtstart|_dtend)$/', $key) && $val != '') {
         $columnName = preg_replace('/(_dtstart|_dtend)$/', '', $key);

--- a/core/tpl/list/objectfields_list_header.tpl.php
+++ b/core/tpl/list/objectfields_list_header.tpl.php
@@ -76,15 +76,6 @@ foreach ($search as $key => $val) {
     } elseif ($val != '') {
         $param .= '&search_' . $key . '=' . urlencode($val);
     }
-    // Propagate include/exclude mode for selectable fields
-    if (array_key_exists($key, $object->fields) && $key !== 'status') {
-        $fieldDef      = $object->fields[$key];
-        $isSelectable  = !empty($fieldDef['arrayofkeyval'])
-            || (isset($fieldDef['type']) && (strpos($fieldDef['type'], 'integer:') === 0 || strpos($fieldDef['type'], 'sellist:') === 0));
-        if ($isSelectable && GETPOST('search_' . $key . '_mode', 'alpha') === 'exc') {
-            $param .= '&search_' . $key . '_mode=exc';
-        }
-    }
 }
 
 // Add $param from extra fields
@@ -233,12 +224,6 @@ if ($useSideFilterPanel && isModEnabled('categorie') && $user->hasRight('categor
 }
 
 // 2. Field filters section inside panel
-$toggleTitlePanelRaw = $langs->trans('ToggleIncludeExclude');
-if ($toggleTitlePanelRaw === 'ToggleIncludeExclude') {
-    $toggleTitlePanelRaw = 'Inverser le filtre (voir tout sauf la sélection)';
-}
-$toggleTitlePanel = dol_escape_htmltag($toggleTitlePanelRaw);
-
 foreach ($object->fields as $key => $val) {
     // Classic mode renders its own inline filter row; skip building the panel rows
     if (!$useSideFilterPanel) {
@@ -263,14 +248,6 @@ foreach ($object->fields as $key => $val) {
 
     // @Todo use showinputfield for all types to benefit from all field definition options (like arrayofkeyval, type=integer:sellist, etc.) instead of only relying on type for field rendering and losing some options in the process (like searchmulti for arrayofkeyval)
     if (!empty($val['arrayofkeyval']) && is_array($val['arrayofkeyval'])) {
-        $showToggle = ($key !== 'status');
-        if ($showToggle) {
-            $fMode  = GETPOST('search_' . $key . '_mode', 'alpha') ?: 'inc';
-            $isExc  = ($fMode === 'exc');
-            $tAttr  = dol_escape_htmltag($fieldLabelPanel) . ' - ' . $toggleTitlePanel;
-            $panelFilterBody .= '<input type="hidden" id="search_' . $key . '_mode" name="search_' . $key . '_mode" value="' . ($isExc ? 'exc' : 'inc') . '">';
-            $panelFilterBody .= '<span id="search_mode_toggle_' . $key . '" title="' . $tAttr . '" class="saturne-filter-mode-toggle ' . ($isExc ? 'saturne-filter-mode-exc' : 'saturne-filter-mode-inc') . '">' . ($isExc ? '<span class="far fa-eye-slash"></span>' : '<span class="far fa-eye"></span>') . '</span>';
-        }
         if (empty($val['searchmulti'])) {
             $panelFilterBody .= $form->selectarray('search_' . $key, $val['arrayofkeyval'], $search[$key] ?? '', 1, 0, 0, '', 1, 0, 0, '', 'maxwidth200' . ($key == 'status' ? ' search_status onrightofpage' : ''), 0);
         } else {
@@ -278,11 +255,6 @@ foreach ($object->fields as $key => $val) {
         }
     } elseif (isset($val['type']) && ((strpos($val['type'], 'integer:') === 0) || (strpos($val['type'], 'sellist:') === 0))) {
         $object->fields[$key]['visible'] = 1; // With visible = 2 the content is hidden
-        $fMode = GETPOST('search_' . $key . '_mode', 'alpha') ?: 'inc';
-        $isExc = ($fMode === 'exc');
-        $tAttr = dol_escape_htmltag($fieldLabelPanel) . ' - ' . $toggleTitlePanel;
-        $panelFilterBody .= '<input type="hidden" id="search_' . $key . '_mode" name="search_' . $key . '_mode" value="' . ($isExc ? 'exc' : 'inc') . '">';
-        $panelFilterBody .= '<span id="search_mode_toggle_' . $key . '" title="' . $tAttr . '" class="saturne-filter-mode-toggle ' . ($isExc ? 'saturne-filter-mode-exc' : 'saturne-filter-mode-inc') . '">' . ($isExc ? '<span class="far fa-eye-slash"></span>' : '<span class="far fa-eye"></span>') . '</span>';
         $panelFilterBody .= $object->showInputField($val, $key, $search[$key] ?? '', '', '', 'search_', $cssForFieldPanel . ' maxwidth200 saturne-panel-select', 1);
     } elseif (isset($val['type']) && in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
         $panelFilterBody .= '<div class="saturne-filter-date-wrapper">'
@@ -409,14 +381,6 @@ if ($useSideFilterPanel) {
 
     // Panel body
     print '<div class="saturne-filter-panel-body">';
-
-    // Legend notice explaining the eye/eye-slash toggle icons
-    print '<div class="saturne-filter-legend">';
-    print '<div class="saturne-filter-legend-items">';
-    print '<span class="saturne-filter-legend-include"><span class="far fa-eye"></span> Inclure</span>';
-    print '<span class="saturne-filter-legend-exclude"><span class="far fa-eye-slash"></span> Exclure</span>';
-    print '</div>';
-    print '</div>';
 
     print $panelFilterBody;
     print '</div>';

--- a/core/tpl/list/objectfields_list_search_input.tpl.php
+++ b/core/tpl/list/objectfields_list_search_input.tpl.php
@@ -47,12 +47,6 @@ if (getDolGlobalString('MAIN_CHECKBOX_LEFT_COLUMN')) {
     print '</td>';
 }
 
-$toggleTitleRaw = $langs->trans('ToggleIncludeExclude');
-if ($toggleTitleRaw == 'ToggleIncludeExclude') {
-    $toggleTitleRaw = 'Inverser le filtre (voir tout sauf la sélection)';
-}
-$toggleTitle = dol_escape_htmltag($toggleTitleRaw);
-
 foreach ($object->fields as $key => $val) {
     $cssForField = saturne_css_for_field($val, $key);
     if (!empty($arrayfields['t.' . $key]['checked'])) {
@@ -66,38 +60,17 @@ foreach ($object->fields as $key => $val) {
         }
 
         if (empty($val['disablesearch'])) {
-            $showModeToggle = false;
-            $fieldLabel     = $langs->trans($val['label'] ?? $key);
             if (!empty($val['arrayofkeyval']) && is_array($val['arrayofkeyval'])) {
-                $showModeToggle = ($key !== 'status');
-                if ($showModeToggle) {
-                    $fieldMode = $search[$key . '_mode'] ?? GETPOST('search_' . $key . '_mode', 'alpha') ?: 'inc';
-                    $isExc     = ($fieldMode === 'exc');
-                    print '<span class="saturne-filter-inline-wrapper">';
-                    print '<input type="hidden" id="search_' . $key . '_mode" name="search_' . $key . '_mode" value="' . ($isExc ? 'exc' : 'inc') . '">';
-                    $titleAttr = dol_escape_htmltag($fieldLabel) . ' - ' . $toggleTitle;
-                    print '<span id="search_mode_toggle_' . $key . '" title="' . $titleAttr . '" class="saturne-filter-mode-toggle ' . ($isExc ? 'saturne-filter-mode-exc' : 'saturne-filter-mode-inc') . '">' . ($isExc ? '<span class="far fa-eye-slash"></span>' : '<span class="far fa-eye"></span>') . '</span>';
-                }
                 if (empty($val['searchmulti'])) {
                     print $form->selectarray('search_' . $key, $val['arrayofkeyval'], $search[$key] ?? '', 1, 0, 0, '', 1, 0, 0, '', 'maxwidth125' . ($key == 'status' ? ' search_status onrightofpage' : ''));
                 } else {
                     print $form->multiselectarray('search_' . $key, $val['arrayofkeyval'], $search[$key] ?? '', 0, 0, 'maxwidth125' . ($key == 'status' ? ' search_status onrightofpage' : ''), 1, '100%');
                 }
-                if ($showModeToggle) {
-                    print '</span>';
-                }
             } elseif (isset($val['type']) && ((strpos($val['type'], 'integer:') === 0) || (strpos($val['type'], 'sellist:') === 0))) {
-                $showModeToggle = true;
-                $fieldMode = $search[$key . '_mode'] ?? GETPOST('search_' . $key . '_mode', 'alpha') ?: 'inc';
-                $isExc     = ($fieldMode === 'exc');
                 // visible=2 hides the field content in showInputField; force visible for the search input
                 if (isset($val['visible']) && (int) $val['visible'] === 2) {
                     $object->fields[$key]['visible'] = 1;
                 }
-                print '<span class="saturne-filter-inline-wrapper">';
-                print '<input type="hidden" id="search_' . $key . '_mode" name="search_' . $key . '_mode" value="' . ($isExc ? 'exc' : 'inc') . '">';
-                $titleAttr = dol_escape_htmltag($fieldLabel) . ' - ' . $toggleTitle;
-                print '<span id="search_mode_toggle_' . $key . '" title="' . $titleAttr . '" class="saturne-filter-mode-toggle ' . ($isExc ? 'saturne-filter-mode-exc' : 'saturne-filter-mode-inc') . '">' . ($isExc ? '<span class="far fa-eye-slash"></span>' : '<span class="far fa-eye"></span>') . '</span>';
                 print $object->showInputField($val, $key, $search[$key] ?? '', '', '', 'search_', $cssForField . ' maxwidth250', 1);
             } elseif (isset($val['type']) && in_array($val['type'], ['date', 'datetime', 'timestamp'])) {
                 print '<div class="nowrap">';
@@ -119,10 +92,6 @@ foreach ($object->fields as $key => $val) {
                 print $formAdmin->select_language(($search[$key] ?? ''), 'search_lang', 0, [], 1, 0, 0, 'minwidth100imp maxwidth125', 2);
             } else {
                 print '<input type="text" class="flat maxwidth' . (isset($val['type']) && in_array($val['type'], ['integer', 'price']) ? '50' : '75') . '" name="search_' . $key . '" value="' . dol_escape_htmltag($search[$key] ?? '') . '">';
-            }
-
-            if (!empty($showModeToggle) && isset($val['type']) && ((strpos($val['type'], 'integer:') === 0) || (strpos($val['type'], 'sellist:') === 0))) {
-                print '</span>'; // close inline-flex wrapper for integer:/sellist: fields
             }
         }
 

--- a/css/scss/modules/filter-panel/_filter-panel.scss
+++ b/css/scss/modules/filter-panel/_filter-panel.scss
@@ -84,39 +84,6 @@
   padding: 20px 20px 8px;
 }
 
-.saturne-filter-legend {
-  margin-bottom: 16px;
-  padding: 8px 12px;
-  background: #f5f9f5;
-  border: 1px solid #d4edda;
-  border-radius: 6px;
-  font-size: 12px;
-  color: #555;
-}
-
-.saturne-filter-legend-items {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.saturne-filter-legend-include,
-.saturne-filter-legend-exclude {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-}
-
-.saturne-filter-legend-include .far {
-  color: #27ae60;
-  font-size: 14px;
-}
-
-.saturne-filter-legend-exclude .far {
-  color: #c0392b;
-  font-size: 14px;
-}
-
 .saturne-filter-btn-wrapper {
   position: relative;
   display: inline-block;
@@ -127,29 +94,6 @@
   top: -6px;
   right: -6px;
   pointer-events: none;
-}
-
-.saturne-filter-mode-toggle {
-  cursor: pointer;
-  font-size: 13px;
-  padding: 0 4px;
-  flex-shrink: 0;
-  user-select: none;
-}
-
-.saturne-filter-mode-inc {
-  color: #27ae60;
-}
-
-.saturne-filter-mode-exc {
-  color: #c0392b;
-}
-
-// Inline search row wrapper (table filter row)
-.saturne-filter-inline-wrapper {
-  display: inline-flex;
-  align-items: center;
-  gap: 2px;
 }
 
 // Search-all block at the top of the panel

--- a/js/modules/filter.js
+++ b/js/modules/filter.js
@@ -57,7 +57,6 @@ window.saturne.filter.event = function() {
     $(document).on('click', '#saturne-filter-toggle', window.saturne.filter.open);
     $(document).on('click', '#saturne-filter-backdrop', window.saturne.filter.close);
     $(document).on('click', '.saturne-filter-panel-close', window.saturne.filter.close);
-    $(document).on('click', '.saturne-filter-mode-toggle', window.saturne.filter.toggleMode);
     $(document).on('click', '.saturne-filter-mode-switch', window.saturne.filter.toggleDisplayMode);
     $(document).on('keydown', window.saturne.filter.handleKeyDown);
 };
@@ -105,23 +104,6 @@ window.saturne.filter.handleKeyDown = function(e) {
     if (e.key === 'Escape') {
         window.saturne.filter.close();
     }
-};
-
-/**
- * Toggle the include/exclude mode of a filter field
- *
- * @since   1.0.0
- * @version 1.0.0
- *
- * @returns {void}
- */
-window.saturne.filter.toggleMode = function() {
-    var key    = this.id.replace('search_mode_toggle_', '');
-    var $input = $('#search_' + key + '_mode');
-    var exc    = $input.val() !== 'exc';
-    $input.val(exc ? 'exc' : 'inc');
-    $(this).html(exc ? '<span class="far fa-eye-slash"></span>' : '<span class="far fa-eye"></span>');
-    $(this).toggleClass('saturne-filter-mode-exc', exc).toggleClass('saturne-filter-mode-inc', !exc);
 };
 
 /**


### PR DESCRIPTION
## Changements

Suppression complète du toggle **œil / œil barré** (inclure / exclure) sur les filtres de liste saturne — les utilisateurs ne comprenaient pas son rôle. Retrait du visuel **et** de tout le traitement derrière :

- **Ligne de filtre inline** : retrait de l'icône œil et du wrapper associé sur les filtres `arrayofkeyval`, `integer:`, `sellist:`.
- **Panneau latéral** : retrait de l'icône œil sur les mêmes champs + suppression de la légende « Inclure / Exclure ».
- **JS** (`filter.js`) : suppression du binding et de la fonction `toggleMode`.
- **URL** : suppression de la propagation du paramètre `search_<champ>_mode`.
- **SQL** (`objectfields_list_build_sql_select.tpl.php`) : suppression de la logique d'exclusion (`!=`, `NOT IN`) — retour au filtre inclusif standard via `natural_search`.
- **SCSS** (`_filter-panel.scss`) : suppression des styles `saturne-filter-mode-*`, `saturne-filter-inline-wrapper` et `saturne-filter-legend*`.

Les filtres reviennent à un comportement inclusif simple et compréhensible.

> L'inclusion/exclusion des **catégories** (tags +/−) n'est pas concernée : visuel distinct et explicite, conservé tel quel.

## Fichiers modifiés

- `core/tpl/list/objectfields_list_search_input.tpl.php`
- `core/tpl/list/objectfields_list_header.tpl.php`
- `core/tpl/list/objectfields_list_build_sql_select.tpl.php`
- `css/scss/modules/filter-panel/_filter-panel.scss`
- `js/modules/filter.js`

> Les assets compilés (`saturne.min.css` / `saturne.min.js`) ne sont pas inclus : ils sont régénérés automatiquement par la CI sur `develop`.

## Issue

#1410
