### PR TITLE
#1412 [List] fix: skip excludeFields in search WHERE to avoid Unknown column on virtual columns

### DIFF
--- a/core/tpl/list/objectfields_list_build_sql_select.tpl.php
+++ b/core/tpl/list/objectfields_list_build_sql_select.tpl.php
@@ -154,6 +154,14 @@ foreach ($search as $key => $val) {
             continue;
         }
 
+        // Virtual/computed/linked fields (listed in $excludeFields) have no real t.<key>
+        // column in the base table. Linked elements are already handled by the
+        // printFieldListSearch hook above; any excluded field still reaching here would
+        // otherwise produce "Unknown column 't.<key>'" (e.g. signatory role columns such
+        // as 'Controller'). Skip the generic column filter for them.
+        if (!empty($excludeFields) && in_array($key, $excludeFields, true)) {
+            continue;
+        }
 
         $mode_search = (($object->isInt($object->fields[$key]) || $object->isFloat($object->fields[$key])) ? 1 : 0);
         if (isset($object->fields[$key]['type']) && ((strpos($object->fields[$key]['type'], 'integer:') === 0) || (strpos($object->fields[$key]['type'], 'sellist:') === 0) || !empty($object->fields[$key]['arrayofkeyval']))) {


### PR DESCRIPTION
## Changements

Dans le constructeur de requête générique des listes, on saute les champs de `$excludeFields` (colonnes virtuelles/calculées/liées) avant de construire le filtre générique `t.<key>` du WHERE :

```php
if (!empty($excludeFields) && in_array($key, $excludeFields, true)) {
    continue;
}
```

## Pourquoi

Ces champs n'ont pas de colonne réelle `t.<key>` dans la table de base. Rechercher dessus générait `t.<colonne> LIKE '%...%'` → `DB_ERROR_NOSUCHFIELD : Unknown column` (ex. colonne de rôle signataire « Controller » sur la liste des contrôles DigiQuali). Les éléments liés restent gérés par le hook `printFieldListSearch` (appelé juste avant) ; un champ virtuel qui n'a pas de hook est désormais simplement ignoré au lieu de casser la requête.

## Fichiers modifiés

- `core/tpl/list/objectfields_list_build_sql_select.tpl.php`

## Issue

#1412
