### PR TITLE
#1422 [List] fix: restore missing New (+) button on all list views

### DIFF
--- a/core/tpl/list/objectfields_list_header.tpl.php
+++ b/core/tpl/list/objectfields_list_header.tpl.php
@@ -190,6 +190,9 @@ if ($mode != 'kanban' && $mode != 'pwa' && !empty($listLayoutId)) {
     $cardButton = ($cardButton ?? '') . ' ' . $filterIndicator;
 }
 
+// "New" button to create a new object
+$cardButton = ($cardButton ?? '') . ' ' . dolGetButtonTitle($langs->trans('New' . ucfirst($object->element)), $helpText ?? '', 'fa fa-plus-circle', ($createUrl ?? dol_buildpath('custom/' . $object->module . '/view/' . $object->element . '/' . $object->element . '_card.php', 1) . '?action=create' . ($moreUrlParameters ?? '')), '', $permissiontoadd);
+
 // Format the title text — record count BEFORE filter indicator
 $titleText = ($conf->browser->layout == 'classic' && $mode != 'pwa') ? ($title ?? '') : '';
 $displayRecordCount = (isset($nbTotalOfRecords) && $nbTotalOfRecords !== '' && is_numeric($nbTotalOfRecords)) ? $nbTotalOfRecords : ($num ?? null);


### PR DESCRIPTION
## Fixes #1422

### Description

Restores the missing **New (+)** button on all Saturne list views.

The button was removed during the filter panel rework (commits related to #1319, #1383, #1410, #1418). The original `dolGetButtonTitle` call for the New button was never re-added after the refactor.

### Changes

**File:** `core/tpl/list/objectfields_list_header.tpl.php`

- Added back the `dolGetButtonTitle` call that generates the New (+) button
- Uses the same pattern as the original code: `dolGetButtonTitle($langs->trans('New' . ucfirst($object->element)), ...)`
- Respects `` override, `` permission check, and ``

### Impact

Affects **all list views** in all Saturne-based modules (DigiQuali, DigiRisk, DoliMeet, DoliCar, etc.).