### PR TITLE
#1424 [Admin] Fix: Undefined variable constArray in object_const_view.tpl.php

### DIFF
--- a/core/tpl/admin/object/object_const_view.tpl.php
+++ b/core/tpl/admin/object/object_const_view.tpl.php
@@ -1,5 +1,6 @@
 <?php
 
+$constArray = $constArray ?? [];
 $parameters = [];
 $reshook    = $hookmanager->executeHooks('saturneAdminObjectConst', $parameters);
 if ($reshook > 0) {


### PR DESCRIPTION
## Description
Warning PHP `Undefined variable \` dans `object_const_view.tpl.php` ligne 29, qui apparait sur toutes les pages admin incluant ce template sans pre-initialiser la variable.

Pages impactees :
- `saturne/admin/documents.php` (une fois par type de document)
- Toute page admin de module externe qui inclut ce template

## Correction
Ajout de `\ = \ ?? [];` en debut de template, avant l'appel au hook.

## Fichier modifie
- `core/tpl/admin/object/object_const_view.tpl.php`

Closes #1424