### PR TITLE
#1426 [List] fix: apply saved column layout on shared list TPL

### DIFF
--- a/core/tpl/list/objectfields_list_header.tpl.php
+++ b/core/tpl/list/objectfields_list_header.tpl.php
@@ -127,6 +127,18 @@ if (!empty($formMoreParams)) {
     }
 }
 
+// Apply the per-user column layout (order + widths) + filter mode saved for this list.
+// Per-module list controllers (control_list.php, question_list.php, ...) reuse these TPLs without
+// running saturne_list.php's layout logic, so applying it here makes the saved layout effective
+// everywhere. saturne_list.php applies it before including this TPL, hence the isset() guards.
+$listLayoutId = $listLayoutId ?? ($object->element ?? '');
+if (!isset($listColumnWidths)) {
+    $listColumnWidths = saturne_apply_list_layout($object, $arrayfields, $listLayoutId);
+}
+if (!isset($useSideFilterPanel)) {
+    $useSideFilterPanel = (saturne_get_list_filter_mode($listLayoutId) === 'panel');
+}
+
 // Apply user column preferences to $arrayfields now, so $panelFilterBody and all loops below use correct checked values
 $selectedFields = '';
 if ($mode != 'pwa' && $mode != 'kanban') {

--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -1213,6 +1213,52 @@ function saturne_get_list_layout(string $listId): array
 }
 
 /**
+ * Apply the per-user column layout (saved order) to a list's fields and return its saved widths.
+ *
+ * Rewrites the 'position' of each field in $object->fields and $arrayfields to match the saved
+ * order, then re-sorts both arrays. Columns absent from the saved order are kept after the ordered
+ * ones. Called by every list using the shared list TPLs (saturne_list.php and the per-module list
+ * controllers reusing core/tpl/list/*) so the saved layout is effective everywhere, not only in
+ * saturne_list.php.
+ *
+ * @param  CommonObject $object      List object (its ->fields are reordered in place)
+ * @param  array        $arrayfields Column definitions keyed by 't.<field>' (reordered in place)
+ * @param  string       $listLayoutId List identifier (e.g. the object element)
+ * @return array<string,int>          Saved column widths (colkey => px), empty when none
+ */
+function saturne_apply_list_layout(CommonObject $object, array &$arrayfields, string $listLayoutId): array
+{
+    $listLayout = saturne_get_list_layout($listLayoutId);
+
+    if (!empty($listLayout['order'])) {
+        $listColumnPos = 0;
+        foreach ($listLayout['order'] as $colKey) {
+            if (isset($object->fields[$colKey])) {
+                $object->fields[$colKey]['position'] = $listColumnPos;
+            }
+            if (isset($arrayfields['t.' . $colKey])) {
+                $arrayfields['t.' . $colKey]['position'] = $listColumnPos;
+            }
+            $listColumnPos += 10;
+        }
+        // Keep columns not present in the saved order after the ordered ones
+        foreach ($object->fields as $colKey => $fieldVal) {
+            if (!in_array($colKey, $listLayout['order'], true)) {
+                $object->fields[$colKey]['position'] = $listColumnPos;
+                if (isset($arrayfields['t.' . $colKey])) {
+                    $arrayfields['t.' . $colKey]['position'] = $listColumnPos;
+                }
+                $listColumnPos += 10;
+            }
+        }
+        $object->fields = dol_sort_array($object->fields, 'position');
+        $arrayfields    = dol_sort_array($arrayfields, 'position');
+    }
+
+    return $listLayout['widths'];
+}
+
+/**
  * Build the user_param key holding a list's per-user filter display mode.
  *
  * @param  string $listId List identifier (e.g. the object element)

--- a/view/saturne_list.php
+++ b/view/saturne_list.php
@@ -155,33 +155,10 @@ require_once DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_list_array_fields.tpl.ph
 
 // Apply the per-user column layout (order + widths) saved for this list
 $listLayoutId     = $object->element;
-$listLayout       = saturne_get_list_layout($listLayoutId);
-$listColumnWidths = $listLayout['widths'];
+$listColumnWidths = saturne_apply_list_layout($object, $arrayfields, $listLayoutId);
 
 // Per-user filter display mode: classic inline row (default) vs side filter panel
 $useSideFilterPanel = (saturne_get_list_filter_mode($listLayoutId) === 'panel');
-if (!empty($listLayout['order'])) {
-    $listColumnPos = 0;
-    foreach ($listLayout['order'] as $colKey) {
-        if (isset($object->fields[$colKey])) {
-            $object->fields[$colKey]['position'] = $listColumnPos;
-        }
-        if (isset($arrayfields['t.' . $colKey])) {
-            $arrayfields['t.' . $colKey]['position'] = $listColumnPos;
-        }
-        $listColumnPos += 10;
-    }
-    // Keep columns not present in the saved order after the ordered ones
-    foreach ($object->fields as $colKey => $fieldVal) {
-        if (!in_array($colKey, $listLayout['order'], true)) {
-            $object->fields[$colKey]['position'] = $listColumnPos;
-            if (isset($arrayfields['t.' . $colKey])) {
-                $arrayfields['t.' . $colKey]['position'] = $listColumnPos;
-            }
-            $listColumnPos += 10;
-        }
-    }
-}
 
 $object->fields = dol_sort_array($object->fields, 'position');
 $arrayfields    = dol_sort_array($arrayfields, 'position');


### PR DESCRIPTION
## Contexte

Sur les listes saturne, réorganiser ou redimensionner les colonnes appelait bien `saturne_save_list_layout` (retour `{success: true}`, ordre stocké en base `llx_user_param`), mais au rechargement les colonnes revenaient à leur ordre par défaut.

**Cause :** la logique qui ré-applique la mise en page sauvegardée vivait uniquement dans `view/saturne_list.php`. Les listes des modules (`control_list.php`, `question_list.php`, liste projet…) sont des contrôleurs propres qui réutilisent les TPL partagés (`core/tpl/list/*`) et le JS de sauvegarde générique, sans jamais exécuter cette logique d'application.

## Changements

- **`lib/saturne_functions.lib.php`** — nouvelle fonction réutilisable `saturne_apply_list_layout()` qui applique l'ordre sauvé (réécriture des `position` + tri de `$object->fields` et `$arrayfields`) et renvoie les largeurs.
- **`core/tpl/list/objectfields_list_header.tpl.php`** — appelle la fonction depuis le TPL header partagé (inclus par toutes les listes), gardé par `isset()` pour ne pas doubler l'application quand `saturne_list.php` l'a déjà faite. Placé avant la construction du sélecteur de colonnes afin que le menu reflète aussi l'ordre.
- **`view/saturne_list.php`** — refactor pour utiliser la même fonction (DRY, -24 lignes).

## Portée

Répare d'un coup toutes les listes réutilisant le TPL partagé (DigiQuali, DigiRisk, DoliCar, DoliLetter, DoliOpi) : ordre des colonnes, largeurs et mode panneau de filtres s'appliquent désormais partout.

## Vérifications

- `php -l` OK sur les 3 fichiers.
- Réorganisation de `$object->fields` après la construction du SQL sans risque : le `SELECT` prend toutes les colonnes, le `WHERE`/`ORDER BY` sont basés sur les clés et non sur l'ordre d'affichage.

## Fichiers modifiés

- `lib/saturne_functions.lib.php`
- `core/tpl/list/objectfields_list_header.tpl.php`
- `view/saturne_list.php`

## Issue

Closes #1426
