### PR TITLE
#1428 [List] fix: working column sort popover and invalid sortfield guard

### DIFF
--- a/core/tpl/list/objectfields_list_build_sql_select.tpl.php
+++ b/core/tpl/list/objectfields_list_build_sql_select.tpl.php
@@ -260,6 +260,33 @@ if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {
     $db->free($resql);
 }
 
+// Guard against an invalid sort field (e.g. a stale URL/session value pointing at a non-sortable
+// linked or computed column such as a linked product) that would crash the whole query with
+// DB_ERROR_NOSUCHFIELD. Build the set of identifiers actually produced by the SELECT and drop the
+// sort when it references something else, so the list self-heals instead of erroring.
+if (!empty($sortfield)) {
+    $validSortFields = [];
+    $selectList      = preg_replace('/^\s*SELECT\s+/i', '', $sqlFields);
+    foreach (explode(',', $selectList) as $selectPart) {
+        $selectPart = trim($selectPart);
+        if (preg_match('/\bAS\s+([A-Za-z0-9_]+)$/i', $selectPart, $matches)) {
+            $validSortFields[$matches[1]] = true;
+        } elseif (preg_match('/^([A-Za-z0-9_]+\.[A-Za-z0-9_]+)$/', $selectPart, $matches)) {
+            $validSortFields[$matches[1]] = true;
+        }
+    }
+
+    foreach (explode(',', $sortfield) as $sortFieldToken) {
+        $sortFieldToken = trim($sortFieldToken);
+        if ($sortFieldToken !== '' && empty($validSortFields[$sortFieldToken])) {
+            dol_syslog('Saturne list: dropping invalid sortfield "' . $sortfield . '" not present in SELECT', LOG_WARNING);
+            $sortfield = '';
+            $sortorder = '';
+            break;
+        }
+    }
+}
+
 // Complete request and execute it with limit
 $sql .= $db->order($sortfield, $sortorder);
 //if (array_key_exists($sortfield, $elementElementFields)) {

--- a/js/modules/filter.js
+++ b/js/modules/filter.js
@@ -237,23 +237,43 @@ window.saturne.filter = {
             }
         });
 
-        $popover.find('.action-sort-asc').on('click', function() {
-            var $a = $th.find('a.reposition'); 
-            if ($a.length) {
-                var href = $a.attr('href');
-                href = href.replace(/sortorder=[^&]*/, 'sortorder=asc');
-                window.location.href = href;
-            }
-        });
+        // "Trier" only applies to columns backed by a sortable base-table field, which render a sort
+        // link. Computed/linked columns (disablesort, e.g. the linked product/thirdparty columns) have
+        // no such link and no real t.<col> in the table: disable the options instead of building an
+        // invalid ORDER BY. The sort field is read from the link to keep the right alias.
+        var $sortLink = $th.find('a.reposition');
+        if ($sortLink.length) {
+            var sortFieldMatch = ($sortLink.attr('href') || '').match(/[?&]sortfield=([^&]+)/);
+            var sortField      = sortFieldMatch ? decodeURIComponent(sortFieldMatch[1]) : '';
 
-        $popover.find('.action-sort-desc').on('click', function() {
-            var $a = $th.find('a.reposition');
-            if ($a.length) {
-                var href = $a.attr('href');
-                href = href.replace(/sortorder=[^&]*/, 'sortorder=desc');
-                window.location.href = href;
-            }
-        });
+            // Rebuild the target URL from the current location so active filters/context are preserved.
+            var sortByColumn = function(direction) {
+                if (!sortField) {
+                    return;
+                }
+                var url = new URL(window.location.href);
+                url.searchParams.set('sortfield', sortField);
+                url.searchParams.set('sortorder', direction);
+                url.searchParams.set('page', '0');
+                window.location.href = url.toString();
+            };
+
+            $popover.find('.action-sort-asc').on('click', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                sortByColumn('asc');
+            });
+
+            $popover.find('.action-sort-desc').on('click', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                sortByColumn('desc');
+            });
+        } else {
+            $popover.find('.action-sort-asc, .action-sort-desc')
+                .css({ opacity: 0.5, cursor: 'not-allowed' })
+                .attr('title', 'Tri non disponible sur cette colonne');
+        }
 
         $popover.find('.action-hide').on('click', function() {
             var colKey = $th.data('colkey');


### PR DESCRIPTION
## Contexte

Deux problèmes liés au tri par colonne des listes saturne :

1. Les boutons « Trier de A à Z » / « Trier de Z à A » du popover de colonne ne fonctionnaient pas (reconstruction d'URL fragile par `replace` du `sortorder` sur le lien toggle).
2. Sur la liste des contrôles, un `sortfield` pointant vers une colonne d'élément lié non triable (`t.fk_product`, `disablesort`) — resté dans l'URL ou la session « lastsearch » — faisait planter la requête (`DB_ERROR_NOSUCHFIELD`) **avant** le rendu, masquant toute la liste.

## Changements

### `js/modules/filter.js`
- Tri reconstruit proprement depuis `window.location` (filtres/contexte préservés) : `sortfield` lu sur le vrai lien de tri de la colonne, `sortorder` forcé, `page` remis à 0, `preventDefault`/`stopPropagation`.
- Options « Trier » **grisées** (comme « Grouper »/« Figer ») sur les colonnes non triables (`disablesort`, sans lien de tri) : pas de tri impossible proposé, donc aucune URL invalide générée.

### `core/tpl/list/objectfields_list_build_sql_select.tpl.php`
- **Garde générique** avant le `ORDER BY` : construction de l'ensemble des identifiants réellement produits par le `SELECT` (colonnes `t.xxx`, alias calculés, extrafields) et abandon de tout `sortfield` absent de cet ensemble.
- La liste **s'auto-répare** : un `sortfield` invalide (URL/session périmée, signet) est purgé pour le reste de la page (formulaire + session) au lieu de planter. Protection valable pour **toutes** les listes saturne.

## Vérifications

- **JSHint** : aucune nouvelle erreur (préexistantes inchangées).
- **`php -l`** OK ; test unitaire de la garde sur le `SELECT` réel du contrôle (DROP `t.fk_product`/`t.fk_soc` ; KEEP `t.ref`/`t.date_creation`/`days_remaining_before_next_control`/extrafields).
- `js/saturne.min.js` non commité (compilé par la CI sur push develop).

## Fichiers modifiés

- `js/modules/filter.js`
- `core/tpl/list/objectfields_list_build_sql_select.tpl.php`

## Issue

Closes #1428
