### PR TITLE
#1430 [Filter] fix: scope le masquage de la ligne de filtres native aux listes Saturne

### DIFF
--- a/css/scss/modules/filter-panel/_filter-panel.scss
+++ b/css/scss/modules/filter-panel/_filter-panel.scss
@@ -1,8 +1,12 @@
 // Column Popover Filter Styles
 // --------------------------------------------------
 
-// Hide the classic filter row visually but keep it in DOM for functionality
-tr.liste_titre_filter {
+// Hide the classic filter row visually but keep it in DOM for functionality.
+// Scope to tables that actually render the Saturne column-filter caret so the
+// rule never leaks to native Dolibarr lists that merely load saturne.min.css
+// (e.g. reedcrm injects it on thirdpartylist/invoicelist/... where no caret
+// replacement exists — the native filter row must stay usable there).
+table:has(.saturne-col-filter-btn) tr.liste_titre_filter {
     display: none !important;
 }
 


### PR DESCRIPTION
Fixes #1430

## Problème

La règle introduite en #1418 masque la ligne de filtres native **sans scope** :

```scss
tr.liste_titre_filter { display: none !important; }
```

Elle fuit sur les listes **natives** où reedcrm charge `saturne.min.css` (contextes `invoicelist|invoicereclist|thirdpartylist|projectlist|propallist`). Sur ces listes aucun caret `.saturne-col-filter-btn` n'est injecté (le caret dépend de `data-colkey`, propre aux listes Saturne), donc la ligne de filtres est masquée **sans remplacement** → filtrage impossible sur tiers / factures / factures récurrentes / projets / propales.

## Correctif

Scoper le masquage à la présence effective du caret Saturne :

```scss
table:has(.saturne-col-filter-btn) tr.liste_titre_filter { display: none !important; }
```

- Sur une liste Saturne (caret présent) : comportement inchangé, la ligne native reste masquée et remplacée par le popover.
- Sur une liste native (pas de caret) : la ligne de filtres native reste visible et utilisable, quel que soit le module qui charge `saturne.min.css`.

`:has()` est supporté par tous les navigateurs cibles (Chrome/Edge 105+, Safari 15.4+, Firefox 121+).

## Test

1. `/societe/list.php` (tiers) → la ligne de filtres de recherche réapparaît et fonctionne.
2. Idem factures, factures récurrentes, projets, propales.
3. Une liste Saturne (ex. DigiQuali) → caret + popover toujours fonctionnels, ligne native toujours masquée.

Seul le SCSS source est modifié ; `saturne.min.css` sera régénéré par la CI au merge.
