### PR TITLE
#1442 [Task] fix: declare SaturneTask::$datec to stop dynamic-property deprecation

### DIFF
--- a/class/task/saturnetask.class.php
+++ b/class/task/saturnetask.class.php
@@ -38,6 +38,13 @@ class SaturneTask extends Task
     public $ismultientitymanaged = 1;
 
     /**
+     * @var int|string Task creation date. Declared explicitly because "datec" is a field of
+     * this object: without the declaration each load/read goes through the parent Task's
+     * deprecated-property handler and raises a PHP 8.2 "dynamic property" deprecation per task.
+     */
+    public $datec;
+
+    /**
      * @var array  Array with all fields and their property. Do not use it as a static var. It may be modified by constructor.
      */
     public $fields = [


### PR DESCRIPTION
Closes #1442

## Problème
`SaturneTask` a `datec` dans son `$fields` mais ne déclarait pas la propriété `$datec`. `datec` étant un alias déprécié dans le `Task` de Dolibarr, chaque chargement/lecture de tâche déclenchait « Creation of dynamic property SaturneTask::\$datec is deprecated ».

Mesuré : **3123 occurrences** sur une fiche risque Digirisk (96,5% du collecteur Error handler du DebugBar).

## Fix
`public $datec;` déclaré sur `SaturneTask`. → 0 deprecation, pour tous les modules Saturne.

## Vérification
Fiche risque Digirisk (élément 13) : Error handler **3235 → 111** après ce fix seul (le reste traité côté Digirisk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)