### PR TITLE
#1446 [Menu] fix: only auto-expand the tree unit on digiriskelement pages

### DIFF
--- a/js/modules/saturneElement.js
+++ b/js/modules/saturneElement.js
@@ -250,7 +250,11 @@ window.saturne.saturneElement.getLeftMenu = function getLeftMenu() {
   const params = new URLSearchParams(window.location.search);
   const id     = params.get('id') || params.get('fromid');
 
-  if (id) {
+  // Only pages that actually display a digiriskelement (whose id maps to a tree #unit) should
+  // expand/highlight the current unit. Other pages reuse the "id" param for a different object
+  // (e.g. the standard card uses it for the standard), which would otherwise wrongly expand the
+  // element that happens to share that id.
+  if (id && window.location.pathname.indexOf('digiriskelement') !== -1) {
     // Call the dedicated function to highlight, expand parents, and scroll to the current unit
     window.saturne.saturneElement.getLeftMenuCurrentUnit(id);
   }


### PR DESCRIPTION
Closes #1446

## Problème
`getLeftMenu()` (saturneElement.js) lit `?id=` de l'URL et déplie/surligne `#unit{id}`. Sur une page qui réutilise `id` pour un autre objet (ex. fiche standard Digirisk `?id=3`), il déplie à tort l'élément partageant cet id.

## Fix
N'appeler `getLeftMenuCurrentUnit(id)` que si `window.location.pathname` contient `digiriskelement`.

## Vérif
Fiche standard `?id=3` : plus de surlignage/dépliage de l'élément 3. Page élément `?id=3` : comportement préservé. Vérifié Playwright. (Complément côté Digirisk : Evarisk/Digirisk#4894.)

> Note assets : `js/saturne.min.js` sera recompilé par la CI à la fusion (source uniquement dans ce PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)