### PR TITLE
#1452 [SCSS] fix: keep button text color on modal-close buttons

### DIFF
--- a/css/scss/modules/modal/_modal.scss
+++ b/css/scss/modules/modal/_modal.scss
@@ -108,12 +108,18 @@
     }
     .modal-close {
       margin-left: auto;
-      color: rgba(0,0,0,0.3);
       padding: 4px;
       transition: all 0.2s ease-out;
       &:hover {
         cursor: pointer;
-        color: $color__primary;
+      }
+      // .modal-close sert aussi de simple hook de fermeture sur des boutons :
+      // leur imposer la couleur de l'icone donnerait un texte bleu sur fond bleu.
+      &:not(.wpeo-button) {
+        color: rgba(0,0,0,0.3);
+        &:hover {
+          color: $color__primary;
+        }
       }
     }
   }


### PR DESCRIPTION
## Changements

- La couleur de texte de `.modal-close` est désormais réservée aux éléments qui ne sont pas des boutons (`&:not(.wpeo-button)`), afin qu'un bouton portant la classe `modal-close` conserve sa propre couleur de texte.
- `margin-left`, `padding`, `transition` et `cursor: pointer` restent appliqués à tous les `.modal-close` : aucun changement de positionnement.

## Contexte

Dans le `modal-header`, le sélecteur `.wpeo-modal .modal-container .modal-header .modal-close` (4 classes) écrasait le `color: #fff` de `.wpeo-button` (1 classe). Un bouton portant aussi `modal-close` affichait donc du noir 30% sur fond bleu au repos, et du `#0d8aff` sur fond `#0d8aff` au survol, soit un texte invisible.

Le pattern « bouton qui ferme aussi la modale » est utilisé à 19 endroits dans Saturne, Digirisk, DigiQuali et Doliletter ; le correctif est donc porté sur le composant partagé plutôt que sur un module.

## Rendu

- Croix de fermeture du header : apparence inchangée (gris translucide, bleu au survol).
- Boutons portant `modal-close` : texte blanc sur fond bleu, lisible au repos comme au survol.

## Fichiers modifiés

- `css/scss/modules/modal/_modal.scss`

`css/saturne.min.css` n'est pas inclus : il est compilé et commité par la CI.

## Issue

Closes #1452
