### PR TITLE
#1454 [Index] fix: logo module grisé sur l'accueil (grayscale v23 sur bandeau de fiche)

### DIFF
--- a/core/tpl/index/index_view.tpl.php
+++ b/core/tpl/index/index_view.tpl.php
@@ -65,7 +65,8 @@ $helpUrl = 'FR:Module_' . $moduleName;
 
 saturne_header(0, '', $title . ' ' . $modModule->version, $helpUrl);
 
-print load_fiche_titre($title . ' ' . $modModule->version, $morehtmlright ?? '', $moduleNameLowerCase . '_color.png@' . $moduleNameLowerCase);
+// The nogreyscale class keeps the module's colored logo visible: Dolibarr v23 applies grayscale(90%) to fiche-title pictos (see style.scss override).
+print load_fiche_titre($title . ' ' . $modModule->version, $morehtmlright ?? '', $moduleNameLowerCase . '_color.png@' . $moduleNameLowerCase, 0, '', 'nogreyscale');
 
 $moduleJustUpdated   = strtoupper($moduleName) . '_JUST_UPDATED';
 $moduleVersion       = strtoupper($moduleName) . '_VERSION';

--- a/css/scss/style.scss
+++ b/css/scss/style.scss
@@ -12,6 +12,12 @@
   border: 5px solid #0d8aff;
 }
 
+/* Dolibarr v23 applies grayscale(90%) to fiche-title picto/title; keep the module colored logo on the home banner (nogreyscale marker set in index_view.tpl.php). */
+.fiche > .table-fiche-title.nogreyscale tr.toptitle td.col-picto,
+.fiche > .table-fiche-title.nogreyscale tr.toptitle td.col-title {
+  filter: none;
+}
+
 /* Drag & drop dropzone for the attached-files upload area (saturne.document.js) */
 .attachareaformuserfile {
   position: relative;


### PR DESCRIPTION
Closes #1454

## Problème
Le logo couleur du module (`{module}_color.png`) dans le bandeau d'accueil s'affiche en niveaux de gris : Dolibarr v23 applique `filter: grayscale(90%)` sur `td.col-picto`/`td.col-title` des `table-fiche-title`, et l'échappatoire `:not(.nogreyscale)` du core ne couvre que la variante `<form>` (que `load_fiche_titre` ne génère pas). Concerne tous les modules Saturne (TPL partagé).

## Correctif
- `core/tpl/index/index_view.tpl.php` : classe `nogreyscale` via le 6ᵉ paramètre `$morecssontable` de `load_fiche_titre`.
- `css/scss/style.scss` : override `filter: none` sur `.fiche > .table-fiche-title.nogreyscale tr.toptitle td.col-picto/col-title` (spécificité (0,5,2) > core (0,4,3), sans `!important`).

`saturne.min.css` non commité — recompilé automatiquement par la CI build-assets sur `develop`.

## Tests (Playwright)
Logo affiché en pleine couleur sur l'accueil Digirisk ; `col-picto`/`col-title` n'ont plus de filtre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)