### PR TITLE
#1456 [Medias] fix: open camera on photo input and restrict file input to documents

### DIFF
--- a/lib/medias.lib.php
+++ b/lib/medias.lib.php
@@ -514,7 +514,10 @@ function saturne_render_media_block(string $moduleName, string $subDir = '', str
         if ($showUpload) {
             $out .= '    <label for="' . $idPrefix . 'upload-media" class="saturne-upload-label">';
             $out .= '      <i class="fas fa-camera"></i>';
-            $out .= '      <input type="file" id="' . $idPrefix . 'upload-media" class="saturne-photo-upload" name="userfile[]" accept="image/*" data-error-not-image="' . dol_escape_htmltag($langs->trans('ErrorFileNotAnImage')) . '" multiple>';
+            // capture="environment" opens the rear camera directly on mobile. Mobile browsers
+            // ignore multiple when capture is set (one shot at a time), desktop ignores capture
+            // and keeps the multiple selection.
+            $out .= '      <input type="file" id="' . $idPrefix . 'upload-media" class="saturne-photo-upload" name="userfile[]" accept="image/*" capture="environment" data-error-not-image="' . dol_escape_htmltag($langs->trans('ErrorFileNotAnImage')) . '" multiple>';
             $out .= '    </label>';
         }
 
@@ -587,7 +590,10 @@ function saturne_render_media_block(string $moduleName, string $subDir = '', str
         if ($showUpload) {
             $out .= '    <label for="' . $idPrefix . 'upload-file" class="saturne-upload-label saturne-upload-label-file" title="' . dol_escape_htmltag($langs->trans('AddFile')) . '">';
             $out .= '      <i class="fas fa-paperclip"></i>';
-            $out .= '      <input type="file" id="' . $idPrefix . 'upload-file" class="saturne-file-upload" name="userfile[]" multiple>';
+            // Listing document types keeps the camera out of the mobile file picker — an input
+            // without accept offers every source, camera included.
+            $fileAccept = '.pdf,.doc,.docx,.odt,.xls,.xlsx,.ods,.ppt,.pptx,.odp,.csv,.txt,.rtf,.zip,.rar,.7z,.eml,.msg';
+            $out .= '      <input type="file" id="' . $idPrefix . 'upload-file" class="saturne-file-upload" name="userfile[]" accept="' . $fileAccept . '" multiple>';
             $out .= '    </label>';
         }
 


### PR DESCRIPTION
## Changements

Sur mobile, les deux boutons d'upload du bloc média se comportaient à l'inverse de leur icône : le bouton appareil photo ouvrait le sélecteur de fichiers, et le bouton trombone proposait la caméra.

- Ajout de `capture="environment"` sur l'input photo : le bouton appareil photo ouvre directement la caméra arrière.
- Ajout d'un `accept` limité aux types documents sur l'input fichier : la caméra ne fait plus partie des sources proposées.

## Points d'attention

- Les navigateurs mobiles ignorent `multiple` quand `capture` est présent : sur téléphone la prise de vue se fait photo par photo. Sur poste de travail `capture` est ignoré, la sélection multiple et le flux « Valider tout » de l'éditeur photo restent inchangés.
- Le bouton trombone n'accepte plus les images : les photos passent désormais uniquement par le bouton appareil photo.

## Fichiers modifiés

- `lib/medias.lib.php`

## Issue

#1456
