### PR TITLE
#1458 [Medias] add: separate shooting and gallery buttons on photo block

### DIFF
--- a/css/scss/modules/medias/_media-block.scss
+++ b/css/scss/modules/medias/_media-block.scss
@@ -59,6 +59,10 @@
   background-color: #34495e !important;
 }
 
+.saturne-upload-label-gallery {
+  background-color: #16a085 !important;
+}
+
 // Inline badge that opens the files modal (mirrors the photo gallery thumbnail)
 .saturne-open-files-library {
   position: relative;

--- a/langs/en_US/medias.lang
+++ b/langs/en_US/medias.lang
@@ -27,6 +27,7 @@ SearchFile                = Search for a file
 PhotoWellSent             = The photo has been added to the media library
 PhotoNotSent              = The photo was not sent correctly
 ConfirmUnlinkMedia        = Are you sure you want to detach the selected media ?
+TakePhoto                 = Take a photo
 AddPhotoFromComputer      = Add a photo from device gallery
 AddPhotoFromMediaGallery  = Add a photo from media gallery
 DeletePhoto               = Delete photo

--- a/langs/fr_FR/medias.lang
+++ b/langs/fr_FR/medias.lang
@@ -28,6 +28,7 @@ PhotoWellSent             = La photo a été ajoutée à la bibliothèque de mé
 PhotoNotSent              = La photo ne s'est pas correctement envoyée
 MediaData                 = Configuration des médias
 ConfirmUnlinkMedia        = Êtes vous sur de vouloir détacher le media sélectionné ?
+TakePhoto                 = Prendre une photo
 AddPhotoFromComputer      = Ajouter une photo depuis la galerie de l'appareil
 AddPhotoFromMediaGallery  = Ajouter une photo depuis la galerie des médias
 DeletePhoto               = Supprimer la photo

--- a/lib/medias.lib.php
+++ b/lib/medias.lib.php
@@ -512,12 +512,19 @@ function saturne_render_media_block(string $moduleName, string $subDir = '', str
         $out .= '  <div class="saturne-media-upload-block" data-module="' . dol_escape_htmltag($moduleNameLowerCase) . '" data-subdir="' . dol_escape_htmltag($subDir) . '">';
 
         if ($showUpload) {
-            $out .= '    <label for="' . $idPrefix . 'upload-media" class="saturne-upload-label">';
+            $errorNotImage = dol_escape_htmltag($langs->trans('ErrorFileNotAnImage'));
+
+            // Shooting button — capture="environment" opens the rear camera directly on mobile.
+            // Mobile browsers ignore multiple when capture is set, hence one shot at a time here.
+            $out .= '    <label for="' . $idPrefix . 'take-photo" class="saturne-upload-label" title="' . dol_escape_htmltag($langs->trans('TakePhoto')) . '">';
             $out .= '      <i class="fas fa-camera"></i>';
-            // capture="environment" opens the rear camera directly on mobile. Mobile browsers
-            // ignore multiple when capture is set (one shot at a time), desktop ignores capture
-            // and keeps the multiple selection.
-            $out .= '      <input type="file" id="' . $idPrefix . 'upload-media" class="saturne-photo-upload" name="userfile[]" accept="image/*" capture="environment" data-error-not-image="' . dol_escape_htmltag($langs->trans('ErrorFileNotAnImage')) . '" multiple>';
+            $out .= '      <input type="file" id="' . $idPrefix . 'take-photo" class="saturne-photo-upload" name="userfile[]" accept="image/*" capture="environment" data-error-not-image="' . $errorNotImage . '">';
+            $out .= '    </label>';
+
+            // Picking button — no capture attribute, so existing photos can be selected, several at once.
+            $out .= '    <label for="' . $idPrefix . 'upload-media" class="saturne-upload-label saturne-upload-label-gallery" title="' . dol_escape_htmltag($langs->trans('AddPhotoFromComputer')) . '">';
+            $out .= '      <i class="fas fa-images"></i>';
+            $out .= '      <input type="file" id="' . $idPrefix . 'upload-media" class="saturne-photo-upload" name="userfile[]" accept="image/*" data-error-not-image="' . $errorNotImage . '" multiple>';
             $out .= '    </label>';
         }
 


### PR DESCRIPTION
## Changements

Suite de #1456. Le `capture="environment"` posé sur l'input photo ouvre bien la caméra, mais les navigateurs mobiles ignorent `multiple` dès que `capture` est présent : plus moyen d'envoyer une photo déjà prise, ni d'en sélectionner plusieurs.

Le bloc photo expose désormais deux boutons distincts :

- **Prendre une photo** (icône appareil photo) — `capture="environment"`, ouvre directement la caméra arrière ;
- **Galerie** (icône images) — `accept="image/*" multiple`, sans `capture`, pour choisir une ou plusieurs photos existantes.

Les deux inputs gardent la classe `saturne-photo-upload` : même contrôle du type image, même passage par l'éditeur photo, même redimensionnement et même upload séquentiel. Le flux « Valider tout » redevient donc accessible depuis un téléphone via le bouton galerie.

Ajouts annexes : classe `.saturne-upload-label-gallery` pour distinguer visuellement les deux boutons, et clé de langue `TakePhoto` en fr/en (`AddPhotoFromComputer` existait déjà pour la galerie).

## Fichiers modifiés

- `lib/medias.lib.php`
- `css/scss/modules/medias/_media-block.scss`
- `langs/fr_FR/medias.lang`
- `langs/en_US/medias.lang`

## Issue

#1458
