### PR TITLE
#1460 [Views] fix: parenthesize null coalescing on moreCSSOnBody

### DIFF
--- a/view/saturne_agenda.php
+++ b/view/saturne_agenda.php
@@ -151,7 +151,7 @@ if ($reshook > 0) {
     $customHeaderFunction = $hookmanager->resPrint;
     $customHeaderFunction($title, $helpUrl);
 } else {
-    saturne_header($hookmanager->resArray['loadMediaGallery'] ?? 0,'', $title, $helpUrl, '', 0, 0, [], [], '', 'mod-' . $object->module . '-' . $object->element . ' page-list bodyforlist ' . $hookmanager->resArray['moreCSSOnBody'] ?? '');
+    saturne_header($hookmanager->resArray['loadMediaGallery'] ?? 0,'', $title, $helpUrl, '', 0, 0, [], [], '', 'mod-' . $object->module . '-' . $object->element . ' page-list bodyforlist ' . ($hookmanager->resArray['moreCSSOnBody'] ?? ''));
 }
 
 if ($id > 0 || !empty($ref)) {

--- a/view/saturne_document.php
+++ b/view/saturne_document.php
@@ -136,7 +136,7 @@ if ($reshook > 0) {
     $customHeaderFunction = $hookmanager->resPrint;
     $customHeaderFunction($title, $helpUrl);
 } else {
-    saturne_header($hookmanager->resArray['loadMediaGallery'] ?? 0, '', $title, $helpUrl, '', 0, 0, [], [], '', 'mod-' . $object->module . '-' . $object->element . ' page-list bodyforlist ' . $hookmanager->resArray['moreCSSOnBody'] ?? '');
+    saturne_header($hookmanager->resArray['loadMediaGallery'] ?? 0, '', $title, $helpUrl, '', 0, 0, [], [], '', 'mod-' . $object->module . '-' . $object->element . ' page-list bodyforlist ' . ($hookmanager->resArray['moreCSSOnBody'] ?? ''));
 }
 
 if ($id > 0 || !empty($ref)) {


### PR DESCRIPTION
## Changements

- Parenthésage du `??` sur `moreCSSOnBody` dans les vues document et agenda, pour qu'il porte sur la lecture du tableau et non sur le résultat de la concaténation

## Détail

L'opérateur `??` a une précédence plus faible que `.`, donc

```php
'... bodyforlist ' . $hookmanager->resArray['moreCSSOnBody'] ?? ''
```

était évalué comme `('... bodyforlist ' . $hookmanager->resArray['moreCSSOnBody']) ?? ''` : la clé était lue sans garde, et le repli ne s'appliquait qu'à une chaîne jamais nulle. D'où trois warnings PHP dès qu'aucun module ne renseignait la clé via le hook.

Le comportement observable ne change pas — l'argument `$morecssonbody` valait déjà la concaténation complète — seul le warning disparaît.

## Fichiers modifiés

- `view/saturne_document.php`
- `view/saturne_agenda.php`

## Tests

- `php -l` OK sur les deux fichiers
- Vue document et vue agenda d'un objet Saturne rechargées sans warning

## Issue

#1460
