### PR TITLE
#1462 [Dashboard] fix: make dashboard list tables scroll instead of the whole page

### DIFF
--- a/class/saturnedashboard.class.php
+++ b/class/saturnedashboard.class.php
@@ -356,23 +356,29 @@ class SaturneDashboard
 
                         print load_fiche_titre($dashboardList['title'], $dashboardList['morehtmlright'], $dashboardList['picto']);
 
+                        // La colonne Ref porte le libellé de la ligne : elle n'est pas tronquée, les colonnes de valeurs le sont
+                        $refCellCss  = $conf->browser->layout == 'classic' ? 'nowraponall ' : '';
+                        $dataCellCss = $conf->browser->layout == 'classic' ? 'nowraponall tdoverflowmax200 ' : '';
+
+                        // Conteneur scrollable : sur mobile le tableau est plus large que l'écran et débordait de la page entière
+                        print '<div class="div-table-responsive-no-min">';
                         print '<table class="noborder centpercent">';
 
                         print '<tr class="liste_titre">';
                         foreach ($dashboardList['labels'] as $key => $dashboardListLabel) {
-                            print '<td class="' . ($conf->browser->layout == 'classic' ? 'nowraponall tdoverflowmax200 ' : '') . (($key != 'Ref') ? 'center' : '') . '">' . $langs->transnoentities($dashboardListLabel) . '</td>';
+                            print '<td class="' . (($key != 'Ref') ? $dataCellCss . 'center' : $refCellCss) . '">' . $langs->transnoentities($dashboardListLabel) . '</td>';
                         }
                         print '</tr>';
 
                         foreach ($dashboardList['data'] as $dashboardListDatasets) {
                             print '<tr class="oddeven">';
                             foreach ($dashboardListDatasets as $key => $dashboardGraphDataset) {
-                                print '<td class="' . ($conf->browser->layout == 'classic' ? 'nowraponall tdoverflowmax200 ' : '') . (($key != 'Ref') ? 'center ' : '') . ($dashboardGraphDataset['morecss'] ?? '') . '"' . ($dashboardGraphDataset['moreAttr'] ?? '') . '>' . $dashboardGraphDataset['value'] . '</td>';
+                                print '<td class="' . (($key != 'Ref') ? $dataCellCss . 'center ' : $refCellCss) . ($dashboardGraphDataset['morecss'] ?? '') . '"' . ($dashboardGraphDataset['moreAttr'] ?? '') . '>' . $dashboardGraphDataset['value'] . '</td>';
                             }
                             print '</tr>';
                         }
 
-                        print '</table></div>';
+                        print '</table></div></div>';
                     }
                 }
             }


### PR DESCRIPTION
Closes #1462

## Problème

Les tableaux de type `list` du dashboard sont plus larges que l'écran sur mobile et font déborder **toute la page** horizontalement (menu compris), au lieu de défiler dans leur propre conteneur.

Mesuré sur le dashboard Digirisk, viewport iPhone SE (320 px, UA mobile) : `document.documentElement.scrollWidth` = 561 px pour une fenêtre de 320 px.

## Correctif

- Le tableau est enveloppé dans `div-table-responsive-no-min` (`overflow-x: auto`) : le débordement reste dans le tableau.
- La colonne `Ref` ne reçoit plus `tdoverflowmax200` : c'est la colonne de libellé, la seule colonne textuelle de ces listes, et `show_dashboard()` force déjà `MAIN_DISABLE_TRUNC = 1`. Elle garde `nowraponall` sur desktop, les colonnes de valeurs restent tronquées comme avant.

## Vérification

Playwright sur le dashboard Digirisk (2 listes : « Liste des risques par catégorie de danger » et « Nombre de tickets par année ») :

| | avant | après |
|---|---|---|
| largeur de page, écran 320 px | 561 px | **320 px** |
| cellules dont le contenu déborde (mobile) | 22 | 0 |
| desktop 1440 px | table 1193 px, libellés complets | identique |

Le rendu desktop est inchangé. Complète Evarisk/Digirisk#4940, qui corrige de son côté les styles inline qui provoquaient la superposition des textes (Evarisk/Digirisk#4449).
