### PR TITLE
#1464 [Admin] feat: colonne image optionnelle dans object_const_view

### DIFF
--- a/core/tpl/admin/object/object_const_view.tpl.php
+++ b/core/tpl/admin/object/object_const_view.tpl.php
@@ -30,10 +30,23 @@ if ($action == 'delete_all_conf') {
 if (is_array($constArray) && !empty($constArray)) {
     print load_fiche_titre($langs->transnoentities('Config'), '', '');
 
+    // An entry may carry a 'tutoImage' key holding the thumbnail HTML built by the calling module.
+    // The column only shows up when at least one setting provides one, so other modules are untouched.
+    $showTutoImages = false;
+    foreach ($constArray[$moduleNameLowerCase] as $const) {
+        if (!empty($const['tutoImage'])) {
+            $showTutoImages = true;
+            break;
+        }
+    }
+
     print '<table class="noborder">';
     print '<tr class="liste_titre">';
     print '<td>' . $langs->transnoentities('Parameters') . '</td>';
     print '<td>' . $langs->transnoentities('Description') . '</td>';
+    if ($showTutoImages) {
+        print '<td class="center">' . $langs->transnoentities('TutoImage') . '</td>';
+    }
     print '<td class="center nowrap">';
     print $langs->transnoentities('Status') . '<br>';
     if ($user->admin) {
@@ -49,6 +62,11 @@ if (is_array($constArray) && !empty($constArray)) {
         print '</td><td>';
         print $langs->trans($const['description']);
         print '</td>';
+        if ($showTutoImages) {
+            print '<td class="center">';
+            print $const['tutoImage'] ?? '';
+            print '</td>';
+        }
         print '<td class="center">';
         if ($user->admin && empty($const['disabled'])) {
             print ajax_constantonoff($const['code'], [], null, 0, 0, 0, 2, 0, 1);

--- a/langs/en_US/saturne.lang
+++ b/langs/en_US/saturne.lang
@@ -23,6 +23,7 @@ ModuleSaturneDesc   = Evarisk framework and library of objects and functions
 ModuleConfig        = Configuration %s
 ModuleConfigSaturne = Configuration Saturne
 MinimizeMenu        = Minimize the menu
+TutoImage           = Image
 
 # Right
 LireModule                  = Read %s

--- a/langs/fr_FR/saturne.lang
+++ b/langs/fr_FR/saturne.lang
@@ -23,6 +23,7 @@ ModuleSaturneDesc   = Framework et librairie d'objets et fonctions d'Evarisk
 ModuleConfig        = Configuration %s
 ModuleConfigSaturne = Configuration Saturne
 MinimizeMenu        = Réduire le menu
+TutoImage           = Image
 
 # Right - Droit
 LireModule                  = Consulter %s

--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -5691,7 +5691,7 @@ parameters:
 		-
 			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
 			identifier: foreach.nonIterable
-			count: 3
+			count: 4
 			path: core/tpl/admin/object/object_const_view.tpl.php
 
 		-
@@ -5737,6 +5737,12 @@ parameters:
 			path: core/tpl/admin/object/object_const_view.tpl.php
 
 		-
+			message: '#^Cannot access offset ''tutoImage'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: core/tpl/admin/object/object_const_view.tpl.php
+
+		-
 			message: '#^Cannot access property \$admin on mixed\.$#'
 			identifier: property.nonObject
 			count: 2
@@ -5769,13 +5775,13 @@ parameters:
 		-
 			message: '#^Cannot call method transnoentities\(\) on mixed\.$#'
 			identifier: method.nonObject
-			count: 4
+			count: 5
 			path: core/tpl/admin/object/object_const_view.tpl.php
 
 		-
 			message: '#^Parameter mixed of print cannot be converted to string\.$#'
 			identifier: print.nonString
-			count: 2
+			count: 3
 			path: core/tpl/admin/object/object_const_view.tpl.php
 
 		-
@@ -5811,13 +5817,13 @@ parameters:
 		-
 			message: '#^Variable \$langs might not be defined\.$#'
 			identifier: variable.undefined
-			count: 10
+			count: 11
 			path: core/tpl/admin/object/object_const_view.tpl.php
 
 		-
 			message: '#^Variable \$moduleNameLowerCase might not be defined\.$#'
 			identifier: variable.undefined
-			count: 3
+			count: 4
 			path: core/tpl/admin/object/object_const_view.tpl.php
 
 		-


### PR DESCRIPTION
Closes #1464

## Besoin

Digirisk illustre ses réglages par une capture de la zone d'interface concernée (Evarisk/Digirisk#4936). Cinq de ses onglets rendent leurs réglages via `object_const_view.tpl.php`, dont les colonnes sont figées : ils ne peuvent pas en bénéficier sans dupliquer le tableau.

## Changement

Une entrée de `$constArray` peut porter une clé `tutoImage` contenant le HTML de la vignette, construit par le module appelant. Saturne reste agnostique : ni le chemin des images, ni leur mise en forme, ni le comportement au clic ne le concernent.

La colonne s'intercale entre *Description* et *État* **uniquement si au moins une entrée fournit une image**. Les modules qui n'utilisent pas la clé rendent donc un tableau strictement identique à aujourd'hui.

Clé de traduction `TutoImage` ajoutée en fr_FR et en_US.

## Vérifications

- `php -l` sur le template : OK.
- Rendu inchangé sur un module sans `tutoImage` (Digirisk avant adaptation), colonne présente et vignettes affichées après adaptation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)