### PR TITLE
#1466 [JS] fix: sort column popover through the search form to keep filters and context

### DIFF
--- a/js/modules/filter.js
+++ b/js/modules/filter.js
@@ -246,11 +246,29 @@ window.saturne.filter = {
             var sortFieldMatch = ($sortLink.attr('href') || '').match(/[?&]sortfield=([^&]+)/);
             var sortField      = sortFieldMatch ? decodeURIComponent(sortFieldMatch[1]) : '';
 
-            // Rebuild the target URL from the current location so active filters/context are preserved.
+            // Sort through the search form so every context carried by its hidden inputs survives.
+            // Rebuilding the URL from window.location only works when the page was reached by GET :
+            // right after a filter/column submit the location has no query string at all, and both
+            // the filters and the page context (fromid/fromtype, object_type, ...) would be dropped.
             var sortByColumn = function(direction) {
                 if (!sortField) {
                     return;
                 }
+
+                var $form = $('#searchFormList');
+                if (!$form.length) {
+                    $form = $th.closest('form');
+                }
+
+                if ($form.length) {
+                    $form.find('input[name="sortfield"]').val(sortField);
+                    $form.find('input[name="sortorder"]').val(direction);
+                    $form.find('input[name="page"]').val('0');
+                    window.saturne.filter.closePopover();
+                    $form.submit();
+                    return;
+                }
+
                 var url = new URL(window.location.href);
                 url.searchParams.set('sortfield', sortField);
                 url.searchParams.set('sortorder', direction);


### PR DESCRIPTION
## Changements

**`js/modules/filter.js`** — `sortByColumn()` du popover de colonne

Le tri reconstruisait son URL cible à partir de `window.location.href`. Or le formulaire de recherche poste sur `PHP_SELF` sans query string : après un filtre, un ajout de colonne ou toute autre soumission, la location n'a plus aucun paramètre et l'URL reconstruite ne contient que `sortfield`, `sortorder` et `page`. Les filtres actifs, le `contextpage` et les paramètres passés par `$formMoreParams` (`fromid` / `fromtype`, `object_type`, ...) sont perdus.

Le tri passe désormais par `#searchFormList` : on renseigne ses champs cachés `sortfield` / `sortorder` / `page` puis on soumet, exactement comme le font déjà « Appliquer » et « Masquer la colonne » dans le même fichier. Tout ce que le formulaire transporte est donc conservé. Le rebuild d'URL est gardé en repli si aucun formulaire n'est trouvé.

Le lien de tri de l'en-tête de colonne (`<a class="reposition">`) n'était pas concerné : il est construit côté serveur avec `$param`.

## Reproduction

Sur une liste ouverte depuis un onglet contextuel (l'onglet Prix concurrent d'un produit dans Priseo, par exemple) : filtrer ou ajouter une colonne, puis trier via le popover d'une colonne.

```
16:17:50 POST  .../competitorprice_list.php                                     200  113739
16:17:57 GET   .../competitorprice_list.php?sortfield=t.entity&sortorder=asc&page=0
                                                                                200   65432   <- contexte perdu
16:18:16 GET   .../competitorprice_list.php?fromid=21&fromtype=product&sortfield=t.entity&sortorder=desc&page=0
                                                                                200  113563
```

Même colonne, même tri : la requête part sans contexte uniquement quand la page a été atteinte par POST. Sur une liste dont le rendu dépend de ce contexte la page paraît vide ; ailleurs l'utilisateur perd silencieusement ses filtres.

## Fichiers modifiés

- `js/modules/filter.js`

`js/saturne.min.js` n'est pas inclus : les assets compilés sont générés par la CI.

## Issue

Closes #1466
