### PR TITLE
#1468 [SCSS] fix: keep modal header above dolibarr sticky top menu

### DIFF
--- a/css/scss/modules/modal/_modal.scss
+++ b/css/scss/modules/modal/_modal.scss
@@ -57,13 +57,23 @@
   }
 }
 
+// Le menu haut Dolibarr (.side-nav-vert) est sticky avec un z-index de 1005, supérieur à celui de la
+// modal active (1002) : sur une fenêtre moins haute que la modal, il recouvrait l'en-tête, masquant
+// le titre et rendant la croix de fermeture incliquable. On le repasse sous l'overlay tant qu'une
+// modal est ouverte.
+body:has(.wpeo-modal.modal-active) .side-nav-vert {
+  z-index: 1001;
+}
+
 .wpeo-modal {
   .modal-container {
     position: absolute;
     transition: all 0.2s ease-out;
     width: 100%;
     max-width: 860px;
-    height: 100%;
+    // Le retrait garde une respiration en haut et en bas quand la fenêtre est moins haute que
+    // max-height : sans lui la modal est collée aux deux bords.
+    height: calc(100% - 4em);
     max-height: 560px;
     background: #fff;
     padding: 1em 0;


### PR DESCRIPTION
Closes #1468
Corrige aussi Evarisk/Digirisk#4351

## Problème

Le menu haut Dolibarr (`header#id-top.side-nav-vert`) est `position: sticky` avec un `z-index` de **1005**, supérieur à celui de l'overlay d'une modal active (**1002**).

`.modal-container` étant en `height: 100%` plafonné par `max-height` (560 px par défaut, 750 px pour les modals d'évaluation Digirisk), toute fenêtre moins haute que ce plafond place la modal à `top: 0` — donc sous le menu haut : titre coupé en deux et **croix de fermeture inaccessible** (`document.elementFromPoint()` au centre de la croix renvoyait `div.mainmenu`).

## Correctif

```scss
body:has(.wpeo-modal.modal-active) .side-nav-vert {
  z-index: 1001;
}

.wpeo-modal .modal-container {
  height: calc(100% - 4em);
}
```

- Le `z-index` de la modal **n'est pas modifié** : le datepicker jQuery (1010) et l'autocomplete (1006) de Dolibarr, qui doivent rester au-dessus du contenu d'une modal, gardent exactement le comportement actuel.
- La règle ne s'applique que pendant qu'une modal est ouverte, et couvre les 10 endroits qui posent `modal-active` (`modal.js`, `media.js`, `audio.js`, `mediaBlock.js`, plus les modules enfants) — un `body.modal-opened` posé en JS aurait été forcément incomplet.
- `:has()` : Chrome/Edge 105+, Safari 15.4+, Firefox 121+.
- `height: calc(100% - 4em)` évite le bord à bord sur écran court ; au-dessus du plafond `max-height` le rendu est inchangé.

## Tests

Playwright sur `saturne.min.css` recompilé, page « Risques » d'une unité de travail Digirisk (Dolibarr 23.0.3) :

| Hauteur fenêtre | `.modal-container` avant | après | titre / croix cliquables |
|---|---|---|---|
| 600 px | `top: 0` | `top: 30` | ✔ |
| 700 px | `top: 0` | `top: 30` | ✔ |
| 800 px | `top: 25` (titre coupé) | `top: 30` | ✔ |
| 1000 px | `top: 125` | `top: 125` (inchangé) | ✔ |

Modal standard (`max-height: 560px`) vérifiée à 400/500/700 px : plus de bord à bord, `top: 30 px` minimum. Après fermeture de la modal, le menu haut retrouve son `z-index: 1005`.

`css/saturne.min.css` n'est pas commité : la CI `build-assets` le régénère.

🤖 Generated with [Claude Code](https://claude.com/claude-code)