### PR TITLE
#4860 [Document] fix: strip quotes from generated file names breaking ODT to PDF conversion

### DIFF
--- a/core/modules/saturne/modules_saturne.php
+++ b/core/modules/saturne/modules_saturne.php
@@ -808,7 +808,10 @@ class SaturneDocumentModel extends CommonDocGenerator
         }
         $newFileTmp = str_replace(' ', '_', $newFileTmp);
         $newFileTmp = $newFileTmp . '.' . $this->type;
-        $fileName   = dol_sanitizeFileName($newFileTmp);
+        // Single quotes are removed too ($includequotes = 1): the ODT to PDF conversion
+        // passes the file name through escapeshellarg() then escapeshellcmd(), which
+        // destroys the shell quoting and makes LibreOffice convert nothing
+        $fileName   = dol_sanitizeFileName($newFileTmp, '_', 1, 1);
 
         $objectDocument->setValueFrom('last_main_doc', $fileName, '', null, '', '', $moreParam['user'], '', '');
         if (!empty($objectDocument->error)) {
@@ -882,7 +885,7 @@ class SaturneDocumentModel extends CommonDocGenerator
                 $srcTemplatePath,
                 [
                     'PATH_TO_TMP' => $conf->$moduleNameLowerCase->dir_temp,
-                    'ZIP_PROXY' => 'PclZipProxy', // PhpZipProxy or PclZipProxy. Got "bad compression method" error when using PhpZipProxy
+                    'ZIP_PROXY' => getDolGlobalString('MAIN_ODF_ZIP_PROXY', 'PclZipProxy'), // PhpZipProxy or PclZipProxy. Got "bad compression method" error when using PhpZipProxy
                     'DELIMITER_LEFT' => '{',
                     'DELIMITER_RIGHT' => '}'
                 ]
@@ -923,6 +926,12 @@ class SaturneDocumentModel extends CommonDocGenerator
         if (!empty($conf->global->MAIN_ODT_AS_PDF) && $conf->global->$confPdfName > 0) {
             try {
                 $odfHandler->exportAsAttachedPDF($file);
+
+                // LibreOffice exits with code 0 even when it could not load the source file,
+                // so the PDF has to be checked before announcing a success
+                if (!file_exists($fileInfos['dirname'] . '/' . $pdfName)) {
+                    throw new Exception('ODT to PDF conversion did not generate any file : ' . $pdfName);
+                }
 
                 $documentUrl = DOL_URL_ROOT . '/document.php';
                 setEventMessages($langs->transnoentities('FileGenerated') . ' - ' . '<a href=' . $documentUrl . '?modulepart=' . $moduleNameLowerCase . '&file=' . urlencode($this->document_type . '/' . $object->ref . '/' . $pdfName) . '&entity=' . $conf->entity . '"' . '>' . $pdfName . '</a>', []);

--- a/core/tpl/documents/saturne_manual_pdf_generation_action.tpl.php
+++ b/core/tpl/documents/saturne_manual_pdf_generation_action.tpl.php
@@ -17,7 +17,7 @@ if ($action == 'pdfGeneration') {
             $file,
             array(
                 'PATH_TO_TMP'     => $conf->$moduleNameLowerCase->dir_temp,
-                'ZIP_PROXY'       => 'PclZipProxy', // PhpZipProxy or PclZipProxy. Got "bad compression method" error when using PhpZipProxy.
+                'ZIP_PROXY'       => getDolGlobalString('MAIN_ODF_ZIP_PROXY', 'PclZipProxy'), // PhpZipProxy or PclZipProxy. Got "bad compression method" error when using PhpZipProxy.
                 'DELIMITER_LEFT'  => '{',
                 'DELIMITER_RIGHT' => '}'
             )
@@ -39,6 +39,13 @@ if ($action == 'pdfGeneration') {
     if (! empty($conf->global->MAIN_ODT_AS_PDF) && $conf->global->$manualPdfGenerationConf > 0) {
         try {
             $odfHandler->exportAsAttachedPDF($file);
+
+            // LibreOffice exits with code 0 even when it could not load the source file,
+            // so the PDF has to be checked before announcing a success
+            if (!file_exists($upload_dir . '/' . $fileInfos['dirname'] . '/' . $pdfName)) {
+                throw new Exception('ODT to PDF conversion did not generate any file : ' . $pdfName);
+            }
+
             $documentUrl = DOL_URL_ROOT . '/document.php';
             setEventMessages($langs->trans("FileGenerated") . ' - ' . '<a href=' .  $documentUrl . '?modulepart=' . $moduleNameLowerCase . '&amp;file=' . urlencode($fileInfos['dirname'] . '/' . $pdfName) . '&entity=' . $conf->entity . '"' . '>' . $pdfName . '</a>', null);
         } catch (Exception $e) {


### PR DESCRIPTION
Closes Evarisk/Digirisk#4860

## Problème

Sur une entité dont le nom de société contient une apostrophe (« Station d'épuration »), la génération du listing de risques annonce « Le fichier a été généré avec succès - X.pdf » mais aucun PDF n'est écrit sur le disque : le lien renvoie « Le fichier n'existe pas ».

## Cause

1. `dol_sanitizeFileName()` ne retire pas les apostrophes sans `$includequotes = 1` : le nom généré était `20260630_GP3_RLD5_Station_d'epuration_specimen.odt`.
2. `odf::exportAsAttachedPDF()` (cœur Dolibarr) construit la commande `soffice` avec `escapeshellarg()` **puis** repasse le tout dans `escapeshellcmd()`. Le quoting est détruit : le binaire reçoit `..._Station_d\epuration_specimen.odt'` au lieu du vrai chemin (vérifié en rejouant la commande dans un shell POSIX).
3. `soffice --convert-to pdf` affiche « Error: source file could not be loaded » **et retourne 0** (vérifié). `$retval == 0` → aucune exception → message de succès mensonger.

## Correctif

- `buildDocumentFilename()` : `dol_sanitizeFileName($newFileTmp, '_', 1, 1)`, plus d'apostrophe dans les noms de documents générés (tous modules Saturne, tous types de documents).
- Génération automatique et manuelle : on vérifie que le PDF existe réellement avant d'annoncer le succès, sinon message d'erreur. Couvre tout échec silencieux de LibreOffice, pas seulement les apostrophes.
- `ZIP_PROXY` configurable via `MAIN_ODF_ZIP_PROXY` (défaut inchangé : `PclZipProxy`), pour pouvoir basculer sur `PhpZipProxy` quand PclZip produit un ODT illisible.

## Tests

- Reproduit en local (Dolibarr 23.0.3, Digirisk) : nom de société avec apostrophe → `20260724_GP1_RLD3_Station_d'epuration_specimen.odt`, identique au ticket.
- Après correctif : `20260724_GP1_RLD4_Station_d_epuration_specimen.odt`, chemin transmis intact au shell, ODT valide (`unzip -t`) et converti par LibreOffice.
- Chemin d'erreur toujours fonctionnel : sans LibreOffice accessible, le message « Le fichier n'a pas pu être généré en PDF » est bien affiché (aucun faux succès).

Les documents déjà générés avec une apostrophe restent non convertibles, il faut les régénérer.