### PR TITLE
#4362 [Admin] fix: build the default document model constant on the object type

### DIFF
--- a/admin/documents.php
+++ b/admin/documents.php
@@ -63,12 +63,13 @@ saturne_load_langs(['admin']);
 $form = new Form($db);
 
 // Get parameters
-$action    = GETPOST('action', 'alpha');
-$modelName = GETPOST('model_name', 'alpha');
-$type      = GETPOST('type', 'alpha');
-$const     = GETPOST('const', 'alpha');
-$label     = GETPOST('label', 'alpha');
-$pageY     = GETPOST('page_y', 'int');
+$action     = GETPOST('action', 'alpha');
+$modelName  = GETPOST('model_name', 'alpha');
+$type       = GETPOST('type', 'alpha');
+$objectType = GETPOST('object_type', 'alpha');
+$const      = GETPOST('const', 'alpha');
+$label      = GETPOST('label', 'alpha');
+$pageY      = GETPOST('page_y', 'int');
 // Used by actions_setmoduleoptions.inc.php
 $modulepart = GETPOST('modulepart', 'aZ09');
 
@@ -108,7 +109,8 @@ if (empty($resHook)) {
 
     // Set default model
     if ($action == 'setdoc') {
-        $confName = dol_strtoupper($moduleName . '_' . $type) . '_DEFAULT_MODEL';
+        // Constant built on the object type, not on the model type, to match the name read when generating a document
+        $confName = dol_strtoupper($moduleName . '_' . $objectType) . '_DEFAULT_MODEL';
         dolibarr_set_const($db, $confName, $modelName, 'chaine', 0, '', $conf->entity);
         header('Location: ' . $_SERVER['PHP_SELF'] . '?module_name=' . $moduleName . '&page_y=' . $pageY);
         exit;

--- a/core/tpl/admin/object/object_document_model_view.tpl.php
+++ b/core/tpl/admin/object/object_document_model_view.tpl.php
@@ -1,10 +1,13 @@
 <?php
 
+// Type stored in the document_model table, it may differ from the object type used by the config constants
+$documentModelType = !empty($documentType) ? $documentType : $documentParentType;
+
 // Select document models
 $def = [];
 $sql = 'SELECT nom';
 $sql .= ' FROM ' . MAIN_DB_PREFIX . 'document_model';
-$sql .= " WHERE type = '" . (!empty($documentType) ? $documentType : $documentParentType) . "'";
+$sql .= " WHERE type = '" . $documentModelType . "'";
 $sql .= ' AND entity = ' . $conf->entity;
 
 $resql = $db->query($sql);
@@ -64,7 +67,7 @@ if (is_array($filelist) && !empty($filelist)) {
                 // Active
                 print '<td class="center">';
                 if (in_array($name, $def)) {
-                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=del&model_name=' . $name . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
+                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=del&model_name=' . $name . '&type=' . $documentModelType . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
                     print img_picto($langs->trans('Enabled'), 'switch_on');
                     print '</a>';
                 } else {
@@ -72,7 +75,7 @@ if (is_array($filelist) && !empty($filelist)) {
                     // description, otherwise saturne_get_list_of_models() would list one entry
                     // per file found in that directory instead of a single model entry.
                     $modelScandir = ($module->type == 'pdf') ? '' : $module->scandir;
-                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=set&model_name=' . $name . '&const=' . $modelScandir . '&label=' . urlencode($module->name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
+                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=set&model_name=' . $name . '&const=' . $modelScandir . '&label=' . urlencode($module->name) . '&type=' . $documentModelType . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
                     print img_picto($langs->trans('Disabled'), 'switch_off');
                     print '</a>';
                 }
@@ -84,7 +87,7 @@ if (is_array($filelist) && !empty($filelist)) {
                 if (getDolGlobalString($defaultModelConf) == $name) {
                     print img_picto($langs->trans('Default'), 'on');
                 } else {
-                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=setdoc&model_name=' . $name . '&const=' . $module->scandir . '&label=' . urlencode($module->name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">' . img_picto($langs->trans('Disabled'), 'off') . '</a>';
+                    print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=setdoc&model_name=' . $name . '&const=' . $module->scandir . '&label=' . urlencode($module->name) . '&object_type=' . $documentParentType . '&module_name=' . $moduleName . '&token=' . newToken() . '">' . img_picto($langs->trans('Disabled'), 'off') . '</a>';
                 }
                 print '</td>';
 
@@ -119,10 +122,10 @@ if (is_array($filelist) && !empty($filelist)) {
                     // Active
                     print '<td class="center">';
                     if (in_array($customName, $def)) {
-                        print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=del&model_name=' . $customName . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
+                        print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=del&model_name=' . $customName . '&type=' . $documentModelType . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
                         print img_picto($langs->trans('Enabled'), 'switch_on');
                     } else {
-                        print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=set&model_name=' . $customName . '&const=' . $module->custom_scandir . '&label=' . urlencode($module->custom_name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
+                        print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=set&model_name=' . $customName . '&const=' . $module->custom_scandir . '&label=' . urlencode($module->custom_name) . '&type=' . $documentModelType . '&module_name=' . $moduleName . '&token=' . newToken() . '">';
                         print img_picto($langs->trans('Disabled'), 'switch_off');
                     }
                     print '</a>';
@@ -133,7 +136,7 @@ if (is_array($filelist) && !empty($filelist)) {
                     if (getDolGlobalString($defaultModelConf) == $customName) {
                         print img_picto($langs->trans('Default'), 'on');
                     } else {
-                        print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=setdoc&model_name=' . $customName . '&const=' . $module->custom_scandir . '&label=' . urlencode($module->custom_name) . '&type=' . explode('_', $name)[0] . '&module_name=' . $moduleName . '&token=' . newToken() . '">' . img_picto($langs->trans('Disabled'), 'off') . '</a>';
+                        print '<a class="reposition" href="' . $_SERVER['PHP_SELF'] . '?action=setdoc&model_name=' . $customName . '&const=' . $module->custom_scandir . '&label=' . urlencode($module->custom_name) . '&object_type=' . $documentParentType . '&module_name=' . $moduleName . '&token=' . newToken() . '">' . img_picto($langs->trans('Disabled'), 'off') . '</a>';
                     }
                     print '</td><td colspan=2></td></tr>';
                 }


### PR DESCRIPTION
Closes Evarisk/Digirisk#4362

## Problème

Dans la configuration des modèles de document, cocher un modèle « par défaut » ne fonctionne pas : le bouton radio reste vide et aucun modèle n'est retenu.

## Cause

L'action `setdoc` construisait la constante à partir du **type de modèle** (`explode('_', $name)[0]`, càd la partie du nom de fichier du modèle), soit `MODULE_<TYPE MODELE>_DEFAULT_MODEL`. Or l'affichage admin (`$defaultModelConf`) et la génération de document lisent `MODULE_<TYPE OBJET>_DEFAULT_MODEL`. La constante écrite n'était donc jamais relue.

## Correctif

- `admin/documents.php` : nouveau paramètre `object_type`, utilisé pour composer la constante de l'action `setdoc`.
- `object_document_model_view.tpl.php` : le type de modèle est résolu une seule fois en haut du template (`$documentModelType`) et réutilisé pour les liens activer/désactiver, au lieu de re-découper le nom de fichier à chaque lien ; les liens `setdoc` transmettent `object_type=$documentParentType`.

Aucun changement de comportement pour l'activation/désactivation des modèles, qui continuent d'utiliser le type stocké dans `llx_document_model`.