### PR TITLE
#1475 [Projet] fix: restrict fetchAllTimeSpentAllUsers to task time records

### DIFF
--- a/class/task/saturnetask.class.php
+++ b/class/task/saturnetask.class.php
@@ -340,6 +340,10 @@ class SaturneTask extends Task
         $sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe as s ON p.fk_soc = s.rowid";
         $sql .= ") AS selector";
         $sql .= " WHERE fk_element = task_id AND project_linked_id = project_id";
+        // La table element_time est partagée entre types d'élément, sans ce filtre une ligne d'un autre type serait rattachée à la tâche de même rowid
+        if ($versionEighteenOrMore) {
+            $sql .= " AND elementtype = 'task'";
+        }
         $sql .= " AND task_entity IN (" . getEntity('project') . ")";
         if ($morewherefilter) {
             $sql .= $morewherefilter;


### PR DESCRIPTION
Closes #1475

## Problème

`SaturneTask::fetchAllTimeSpentAllUsers()` lit `llx_element_time` sans filtrer `elementtype = 'task'`, contrairement au coeur (`Task::fetchAllTimeSpent()`). La jointure ne repose que sur `fk_element = pt.rowid` : une ligne de temps d'un autre type d'élément dont le `fk_element` coïncide avec un `rowid` de tâche est rattachée à cette tâche et comptée dans les durées et les coûts.

La table est partagée par nature (elle porte déjà `intervention_id` / `intervention_line_id`), la collision de rowid n'a rien d'improbable.

## Correctif

Ajout de `AND elementtype = 'task'` dans le `WHERE`, uniquement pour Dolibarr >= 18 : sous cette version la méthode interroge `llx_projet_task_time`, qui n'a pas cette colonne.

## Test

Base de dev, projet 282 (17 tâches, 395 lignes de temps, 5 948,09 €). Insertion d'une ligne `llx_element_time` `elementtype = 'ticket'`, `fk_element` = rowid d'une tâche du projet, 1 h à 1 000 € :

| | lignes retournées | coût calculé | vs SQL de référence |
|---|---|---|---|
| avant | 396 | 6 948,09 € | divergence |
| après | 395 | 5 948,09 € | concordance |

Ligne de test supprimée, table revenue à son état initial (12 729 lignes).

Détecté en corrigeant les indicateurs projet Digirisk — Evarisk/Digirisk#4272.