### PR TITLE
#1477 [List] fix: count grouped rows and stop inline editing of read-only objects

### DIFF
--- a/core/ajax/saturne_update_field.php
+++ b/core/ajax/saturne_update_field.php
@@ -72,6 +72,14 @@ if ($action == 'update_field') {
         exit;
     }
 
+    // State guard: a locked or archived object is read-only, hiding the editor client-side is not enough
+    if (method_exists($object, 'isModifiable') && !$object->isModifiable()) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'error' => 'ObjectNotModifiable']);
+        $db->close();
+        exit;
+    }
+
     $format = '';
     switch ($type) {
         case 'datepicker':

--- a/core/tpl/list/objectfields_list_build_sql_select.tpl.php
+++ b/core/tpl/list/objectfields_list_build_sql_select.tpl.php
@@ -248,7 +248,8 @@ if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {
         $sqlForCount = 'SELECT COUNT(*) as nbtotalofrecords FROM (' . $sqlForList . ') as countedrows';
     } else {
         /* The fast and low memory method to get and count full list converts the sql into a sql count */
-        $sqlForCount = preg_replace('/^' . preg_quote($sqlFields, '/') . '/', 'SELECT COUNT(*) as nbtotalofrecords', $sql);
+        $countSelect = 'SELECT COUNT(*) as nbtotalofrecords';
+        $sqlForCount = preg_replace('/^' . preg_quote($sqlFields, '/') . '/', $countSelect, $sql);
         // Only strip the extrafields LEFT JOIN (not searchAll joins which are referenced in WHERE)
         $sqlForCount = preg_replace('/ LEFT JOIN \S+_extrafields\s+as\s+ef\s+ON\s+\([^)]+\)/', '', $sqlForCount);
     }

--- a/core/tpl/list/objectfields_list_build_sql_select.tpl.php
+++ b/core/tpl/list/objectfields_list_build_sql_select.tpl.php
@@ -239,11 +239,19 @@ $sqlForList = $sql;
 // Count total nb of records
 $nbTotalOfRecords = '';
 if (!getDolGlobalInt('MAIN_DISABLE_FULL_SCANLIST')) {
-    /* The fast and low memory method to get and count full list converts the sql into a sql count */
-    $sqlForCount = preg_replace('/^' . preg_quote($sqlFields, '/') . '/', 'SELECT COUNT(*) as nbtotalofrecords', $sql);
-    // Only strip the extrafields LEFT JOIN (not searchAll joins which are referenced in WHERE)
-    $sqlForCount = preg_replace('/ LEFT JOIN \S+_extrafields\s+as\s+ef\s+ON\s+\([^)]+\)/', '', $sqlForCount);
-    $sqlForCount = preg_replace('/GROUP BY .*$/', '', $sqlForCount);
+    if (preg_match('/\bGROUP\s+BY\b/i', $sqlForList)) {
+        // A printFieldListFrom hook can add a JOIN that multiplies the rows of one object (one row
+        // per linked record), collapsed again by the GROUP BY of printFieldListGroupBy - and possibly
+        // filtered on that aggregate by printFieldListHaving. Turning the SELECT into a COUNT(*) and
+        // dropping the GROUP BY would count the joined rows instead of the objects, so count the rows
+        // the grouped query actually returns.
+        $sqlForCount = 'SELECT COUNT(*) as nbtotalofrecords FROM (' . $sqlForList . ') as countedrows';
+    } else {
+        /* The fast and low memory method to get and count full list converts the sql into a sql count */
+        $sqlForCount = preg_replace('/^' . preg_quote($sqlFields, '/') . '/', 'SELECT COUNT(*) as nbtotalofrecords', $sql);
+        // Only strip the extrafields LEFT JOIN (not searchAll joins which are referenced in WHERE)
+        $sqlForCount = preg_replace('/ LEFT JOIN \S+_extrafields\s+as\s+ef\s+ON\s+\([^)]+\)/', '', $sqlForCount);
+    }
     $resql = $db->query($sqlForCount);
     if ($resql) {
         $objForCount      = $db->fetch_object($resql);

--- a/core/tpl/list/objectfields_list_loop_object.tpl.php
+++ b/core/tpl/list/objectfields_list_loop_object.tpl.php
@@ -134,12 +134,14 @@ while ($i < $iMaxInLoop) {
                 } elseif ($key == 'rowid') {
                     print $object->showOutputField($val, $key, $object->id);
                 } else {
-                    // Inline edit: auto-detect an editor per field type (when the user can write and the object is still modifiable)
-                    // A locked or archived object is read-only on its card ($object->status < STATUS_LOCKED), so its
-                    // fields must not be editable from the list either
-                    $isModifiable = !method_exists($object, 'isModifiable') || $object->isModifiable();
-                    $inlineType   = (!empty($permissiontoadd) && $isModifiable) ? saturne_get_inline_edit_type($val, $key) : '';
-                    if ($inlineType === '' && $isModifiable && !empty($val['contenteditable']) && $val['contenteditable'] == 1) {
+                    // Inline edit: auto-detect an editor per field type, when the user can write
+                    // and the object is still modifiable. A locked or archived object is read-only
+                    // on its card, so its fields must not be editable from the list either
+                    $isModifiable      = !method_exists($object, 'isModifiable') || $object->isModifiable();
+                    $canInlineEdit     = !empty($permissiontoadd) && $isModifiable;
+                    $isContentEditable = !empty($val['contenteditable']) && $val['contenteditable'] == 1;
+                    $inlineType        = $canInlineEdit ? saturne_get_inline_edit_type($val, $key) : '';
+                    if ($inlineType === '' && $isModifiable && $isContentEditable) {
                         $inlineType = (!empty($val['type']) && in_array($val['type'], ['date', 'datetime'])) ? 'datepicker' : 'text';
                     }
 

--- a/core/tpl/list/objectfields_list_loop_object.tpl.php
+++ b/core/tpl/list/objectfields_list_loop_object.tpl.php
@@ -134,9 +134,12 @@ while ($i < $iMaxInLoop) {
                 } elseif ($key == 'rowid') {
                     print $object->showOutputField($val, $key, $object->id);
                 } else {
-                    // Inline edit: auto-detect an editor per field type (always editable when the user can write)
-                    $inlineType = !empty($permissiontoadd) ? saturne_get_inline_edit_type($val, $key) : '';
-                    if ($inlineType === '' && !empty($val['contenteditable']) && $val['contenteditable'] == 1) {
+                    // Inline edit: auto-detect an editor per field type (when the user can write and the object is still modifiable)
+                    // A locked or archived object is read-only on its card ($object->status < STATUS_LOCKED), so its
+                    // fields must not be editable from the list either
+                    $isModifiable = !method_exists($object, 'isModifiable') || $object->isModifiable();
+                    $inlineType   = (!empty($permissiontoadd) && $isModifiable) ? saturne_get_inline_edit_type($val, $key) : '';
+                    if ($inlineType === '' && $isModifiable && !empty($val['contenteditable']) && $val['contenteditable'] == 1) {
                         $inlineType = (!empty($val['type']) && in_array($val['type'], ['date', 'datetime'])) ? 'datepicker' : 'text';
                     }
 


### PR DESCRIPTION
Closes #1477

Constaté sur `digiquali/view/sheet/sheet_list.php`, corrigé dans les templates de liste génériques.

## 1. Compteur faussé par les JOIN des hooks

`printFieldListFrom` ajoute un JOIN produisant une ligne par enregistrement lié, que `printFieldListGroupBy` regroupe ensuite. La requête de comptage transformait le SELECT en `COUNT(*)` **et retirait le GROUP BY** : elle comptait les lignes jointes.

On compte désormais les lignes réellement renvoyées par la requête groupée, ce qui respecte aussi un `printFieldListHaving` filtrant sur l'agrégat (recherche par nombre de questions). Les listes sans GROUP BY gardent le chemin rapide inchangé — seul DigiQuali déclare un `printFieldListGroupBy` aujourd'hui.

| Filtre statut (modèles) | Réel | Avant | Après |
|---|---|---|---|
| En cours | 3 | 5 | 3 |
| Verrouillé | 24 | 138 | 24 |
| Archivé | 20 | 159 | 20 |
| En cours + Verrouillé | 27 | 143 | 27 |
| Les trois | 47 | 302 | 47 |

## 2. Édition en ligne sur objet verrouillé / archivé

Les éditeurs en ligne étaient activés dès que l'utilisateur avait le droit d'écriture, sans regarder l'état de l'objet : on pouvait changer depuis la liste le type d'un modèle verrouillé ou archivé, alors que sa fiche est en lecture seule.

Ils sont maintenant conditionnés à `isModifiable()` — méthode qui existait déjà et porte exactement cette règle (`status < STATUS_LOCKED`), utilisée par les fiches DigiQuali. `saturne_update_field.php` refuse également l'écriture : masquer l'éditeur côté client laisserait l'endpoint ouvert à une requête forgée.

Le test `method_exists()` préserve les listes dont l'objet n'étend pas `SaturneObject`.

## Vérification

Sur la liste des modèles DigiQuali :

- compteur exact pour les 5 combinaisons de filtres du tableau ci-dessus ;
- lignes « En cours » : éditeurs en ligne toujours présents (3 selects, 9 champs éditables) ; lignes « Verrouillé » et « Archivé » : **aucun** ;
- requête forgée sur `saturne_update_field.php` visant le type d'un modèle archivé → `403 ObjectNotModifiable`, valeur inchangée en base ; la même requête sur un modèle « En cours » → `200`, valeur mise à jour.

Les listes contrôles / enquêtes / questions ont été revérifiées : compteurs inchangés (pas de GROUP BY, chemin rapide conservé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
