### PR TITLE
#1479 [List] feat: add an opt-in Validate mass action on object lists

### DIFF
--- a/core/tpl/actions/list_massactions.tpl.php
+++ b/core/tpl/actions/list_massactions.tpl.php
@@ -27,8 +27,49 @@
  * Global     : $db, $langs, $user,
  * Parameters : $action, $confirm, $massaction, $toselect
  * Objects    : $object
- * Variable   : $objectclass, $permissiontoadd
+ * Variable   : $enableMassValidate (optional), $objectclass, $permissiontoadd
  */
+
+// Validate mass action - only offered on lists that opted in with $enableMassValidate
+$validateAsked = ($massaction == 'validate' || ($action == 'validate' && $confirm == 'yes'));
+if ($validateAsked && !empty($enableMassValidate) && $permissiontoadd) {
+    if (!empty($toselect)) {
+        $nbOk      = 0;
+        $nbSkipped = 0;
+        $error     = 0;
+        $objectTmp = new $objectclass($db);
+        foreach ($toselect as $toSelectedID) {
+            $result = $objectTmp->fetch($toSelectedID);
+            if ($result > 0) {
+                // Only a draft object can be validated, else a locked or archived one would go back to the validated status
+                if ($objectTmp->status != $objectTmp::STATUS_DRAFT) {
+                    $nbSkipped++;
+                    continue;
+                }
+
+                $result = $objectTmp->validate($user);
+                if ($result > 0) {
+                    $nbOk++;
+                } else {
+                    setEventMessages($objectTmp->error, $objectTmp->errors, 'errors');
+                    $error++;
+                    break;
+                }
+            } else {
+                setEventMessages($objectTmp->error, $objectTmp->errors, 'errors');
+                $error++;
+                break;
+            }
+        }
+
+        if ($error == 0) {
+            setEventMessages($langs->trans('RecordsValidated', $nbOk), []);
+            if ($nbSkipped > 0) {
+                setEventMessages($langs->trans('RecordsNotDraftSkipped', $nbSkipped), [], 'warnings');
+            }
+        }
+    }
+}
 
 // Archive mass action
 if (($massaction == 'archive' || ($action == 'archive' && $confirm == 'yes')) && $permissiontoadd) {

--- a/core/tpl/list/objectfields_list_header.tpl.php
+++ b/core/tpl/list/objectfields_list_header.tpl.php
@@ -27,9 +27,9 @@
  * Globals    : $conf, $db, $hookmanager, $langs, $user
  * Parameters : $action, $limit, $contextpage, $massaction, $mode, $optioncss, $page, $searchAll, $sortfield, $sortorder, $toselect
  * Objects    : $categorie, $extrafields (extrafields_list_search_param.tpl), $form, $object
- * Variables  : $arrayfields, $createUrl (optional), $fieldsToSearchAll, $formMoreParams (optional), $helpText (optional),
- *              $nbTotalOfRecords, $num, $permissiontoadd, $resql, $search, $search_array_options (extrafields_list_search_param.tpl),
- *              $searchCategories, $sql, $title
+ * Variables  : $arrayfields, $createUrl (optional), $enableMassValidate (optional), $fieldsToSearchAll,
+ *              $formMoreParams (optional), $helpText (optional), $nbTotalOfRecords, $num, $permissiontoadd, $resql,
+ *              $search, $search_array_options (extrafields_list_search_param.tpl), $searchCategories, $sql, $title
  */
 
 // Output page
@@ -87,8 +87,15 @@ $hookmanager->executeHooks('printFieldListSearchParam', $parameters, $object, $a
 $param .= $hookmanager->resPrint;
 
 // List of mass actions available
-$arrayOfMassActions = [
-    //'validate'=>img_picto('', 'check', 'class="pictofixedwidth"').$langs->trans("Validate"),
+$arrayOfMassActions = [];
+
+// Mass validation is opt-in: the list page must set $enableMassValidate, every object is not meant to be validated in bulk
+if (!empty($enableMassValidate) && !empty($permissiontoadd)) {
+    $validatePicto = '<span class="fas fa-check paddingrightonly"></span>';
+    $arrayOfMassActions['prevalidate'] = $validatePicto . $langs->trans('Validate');
+}
+
+$arrayOfMassActions += [
     //'generate_doc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("ReGeneratePDF"),
     //'builddoc'=>img_picto('', 'pdf', 'class="pictofixedwidth"').$langs->trans("PDFMerge"),
     //'presend'=>img_picto('', 'email', 'class="pictofixedwidth"').$langs->trans("SendByMail"),
@@ -234,6 +241,10 @@ print_barre_liste($listTitle, ($page ?? 0), $_SERVER['PHP_SELF'], ($param ?? '')
 //$trackid = 'xxxx'.$object->id;
 
 require_once DOL_DOCUMENT_ROOT . '/core/tpl/massactions_pre.tpl.php';
+
+if ($massaction == 'prevalidate') {
+    print $form->formconfirm($_SERVER['PHP_SELF'], $langs->trans('ConfirmMassValidate'), $langs->trans('ConfirmMassValidatingQuestion', count($toselect)), 'validate', null, '', 0, 200, 500, 1);
+}
 
 if ($massaction == 'prearchive') {
     print $form->formconfirm($_SERVER['PHP_SELF'], $langs->trans('ConfirmMassArchive'), $langs->trans('ConfirmMassArchivingQuestion', count($toselect)), 'archive', null, '', 0, 200, 500, 1);

--- a/langs/en_US/object.lang
+++ b/langs/en_US/object.lang
@@ -100,16 +100,20 @@ CloneCategories         = Clone tags/categories ?
 ClonePhotos             = Cloner les photos ?
 
 # Confirm mass box
-ConfirmMassLock              = Bulk lock confirmation
-ConfirmMassLockingQuestion   = Are you sure you want to lock the %d record(s) selected ?
-ConfirmMassArchive           = Bulk archiving confirmation
-ConfirmMassArchivingQuestion = Are you sure you want to archive the %d record(s) selected ?
+ConfirmMassLock               = Bulk lock confirmation
+ConfirmMassLockingQuestion    = Are you sure you want to lock the %d record(s) selected ?
+ConfirmMassArchive            = Bulk archiving confirmation
+ConfirmMassArchivingQuestion  = Are you sure you want to archive the %d record(s) selected ?
+ConfirmMassValidate           = Bulk validation confirmation
+ConfirmMassValidatingQuestion = Are you sure you want to validate the %d record(s) selected ?
 
 # SetEventMessage mass action
 RecordsArchived = %d record(s) archived
 ConfirmMassUnarchive           = Bulk unarchiving confirmation
 ConfirmMassUnarchivingQuestion = Are you sure you want to unarchive the %d record(s) selected ?
 RecordsUnarchived = %d record(s) unarchived
+RecordsValidated = %d record(s) validated
+RecordsNotDraftSkipped = %d record(s) skipped because they are not in draft status
 Unarchive = Unarchive
 Unarchived = Unarchived
 ObjectNotFound  = %s not found

--- a/langs/fr_FR/object.lang
+++ b/langs/fr_FR/object.lang
@@ -102,16 +102,20 @@ CloneCategories         = Cloner les tags/catégories ?
 ClonePhotos             = Cloner les photos ?
 
 # Confirm mass box - Boite de confirmation mass action
-ConfirmMassLock              = Confirmation de verrouillage en masse
-ConfirmMassLockingQuestion   = Êtes-vous sur de vouloir verrouiller les %d enregistrement(s) sélectionné(s) ?
-ConfirmMassArchive           = Confirmation de archivage en masse
-ConfirmMassArchivingQuestion = Êtes-vous sur de vouloir archiver les %d enregistrement(s) sélectionné(s) ?
+ConfirmMassLock               = Confirmation de verrouillage en masse
+ConfirmMassLockingQuestion    = Êtes-vous sur de vouloir verrouiller les %d enregistrement(s) sélectionné(s) ?
+ConfirmMassArchive            = Confirmation de archivage en masse
+ConfirmMassArchivingQuestion  = Êtes-vous sur de vouloir archiver les %d enregistrement(s) sélectionné(s) ?
+ConfirmMassValidate           = Confirmation de validation en masse
+ConfirmMassValidatingQuestion = Êtes-vous sûr de vouloir valider les %d enregistrement(s) sélectionné(s) ?
 
 # SetEventMessage mass action - Notice mass action
 RecordsArchived = %d enregistrement(s) archivé(s)
 ConfirmMassUnarchive           = Confirmation du désarchivage en masse
 ConfirmMassUnarchivingQuestion = Êtes-vous sûr de vouloir désarchiver les %d enregistrement(s) sélectionné(s) ?
 RecordsUnarchived = %d enregistrement(s) désarchivé(s)
+RecordsValidated = %d enregistrement(s) validé(s)
+RecordsNotDraftSkipped = %d enregistrement(s) ignoré(s) car ils ne sont pas au statut brouillon
 Unarchive = Désarchiver
 Unarchived = Désarchivé
 ObjectNotFound  = %s non trouvé(e)


### PR DESCRIPTION
Closes #1479

## Contexte

Les listes Saturne ne proposaient que `Archiver`, `Désarchiver` et `Supprimer` en action de masse. Valider plusieurs enregistrements imposait d'ouvrir chaque fiche une par une.

## Ce que fait la PR

Ajoute une action de masse **Valider** générique, réutilisable par tous les modules basés sur Saturne, calquée sur `Archiver` :

- `core/tpl/list/objectfields_list_header.tpl.php` — entrée dans le menu d'actions de masse + boîte de confirmation ;
- `core/tpl/actions/list_massactions.tpl.php` — traitement via `SaturneObject::validate()` ;
- `langs/{fr_FR,en_US}/object.lang` — nouvelles clés (bloc « Confirm mass box » réaligné au passage).

## Choix de conception

**Opt-in.** L'action n'apparaît que si la page de liste pose `$enableMassValidate`. Sans ce garde-fou, elle se déverserait d'un coup sur toutes les listes de tous les modules, alors que tous les objets n'ont pas vocation à être validés en masse.

**Garde-fou statut.** Seuls les brouillons sont validés. Sans ce filtre, `validate()` remettrait un objet *verrouillé* ou *archivé* au statut *validé* — régression silencieuse. Les autres sont ignorés avec un avertissement chiffré, sans faire échouer le reste du lot.

**Nom de clé.** `ConfirmMassValidatingQuestion` et non `ConfirmMassValidationQuestion` : cette dernière existe déjà dans le `propal.lang` du cœur, sans le `%d`, et gagnait sur la nôtre — le message s'affichait sans le compteur. Le nom retenu est aussi cohérent avec `ConfirmMassArchivingQuestion` voisine.

## Tests

Vérifié en local (Dolibarr 23, Playwright) sur les deux listes DigiQuali, en sélectionnant un brouillon **et** un enregistrement verrouillé :

```
Confirmation de validation en masse
Êtes-vous sûr de vouloir valider les 2 enregistrement(s) sélectionné(s) ?

1 enregistrement(s) validé(s)
1 enregistrement(s) ignoré(s) car ils ne sont pas au statut brouillon

contrôles      FC2602-0054 : Brouillon -> Validé   FC2512-0053 : Verrouillé -> Verrouillé
questionnaires SY2603-0135 : Brouillon -> Validé   SY2601-0111 : Verrouillé -> Verrouillé
```

Aucune liste existante n'est modifiée : sans `$enableMassValidate`, le menu d'actions de masse est identique à avant.

Activation côté module : Evarisk/digiquali#2492

🤖 Generated with [Claude Code](https://claude.com/claude-code)