### PR TITLE
#1481 [SaturneObject] fix: stop reading typed properties an object never received

### DIFF
--- a/class/saturneobject.class.php
+++ b/class/saturneobject.class.php
@@ -613,10 +613,12 @@ abstract class SaturneObject extends CommonObject
         if (isset($this->status)) {
             $datas['picto'] .= ' ' . $this->getLibStatut(5);
         }
-        if (property_exists($this, 'ref')) {
+        // isset() rather than property_exists(): a typed property left uninitialized
+        // by a failed fetch() does exist, but reading it raises a fatal error
+        if (isset($this->ref)) {
             $datas['ref'] = '<br><b>' . $langs->trans('Ref') . ' : </b> ' . $this->ref;
         }
-        if (property_exists($this, 'label')) {
+        if (isset($this->label)) {
             $datas['label'] = '<br><b>' . $langs->trans('Label') . ' : </b> ' . $this->label;
         }
 
@@ -720,7 +722,7 @@ abstract class SaturneObject extends CommonObject
             if ($withPicto == 3) {
                 $addLabel = 1;
             }
-            $result .= (($addLabel && property_exists($this, 'label')) ? '<span class="opacitymedium"> - <span contenteditable="true" data-field="label">' . dol_trunc($this->label, ($addLabel > 1 ? $addLabel : 0)) . '</span></span>' : '');
+            $result .= (($addLabel && isset($this->label)) ? '<span class="opacitymedium"> - <span contenteditable="true" data-field="label">' . dol_trunc($this->label, ($addLabel > 1 ? $addLabel : 0)) . '</span></span>' : '');
         }
 
         $hookmanager->initHooks([$this->element . 'dao']);
@@ -1103,13 +1105,13 @@ abstract class SaturneObject extends CommonObject
         if ($selected >= 0) {
             $out .= '<input id="cb' . $this->id . '" class="flat checkforselect fright" type="checkbox" name="toselect[]" value="' . $this->id . '"' . ($selected ? ' checked="checked"' : '') . '>';
         }
-        if (property_exists($this, 'label')) {
+        if (isset($this->label)) {
             $out .= '<div class="inline-block opacitymedium valignmiddle tdoverflowmax100">' . $this->label . '</div>';
         }
-        if (property_exists($this, 'thirdparty') && is_object($this->thirdparty)) {
+        if (isset($this->thirdparty) && is_object($this->thirdparty)) {
             $out .= '<br><div class="info-box-ref tdoverflowmax150">' . $this->thirdparty->getNomUrl(1) . '</div>';
         }
-        if (method_exists($this, 'getLibStatut')) {
+        if (isset($this->status) && method_exists($this, 'getLibStatut')) {
             $out .= '<br><div class="info-box-status">' . $this->getLibStatut(3) . '</div>';
         }
         $out .= '</div>';


### PR DESCRIPTION
Closes #1481

## Problème

`property_exists()` renvoie `true` pour une propriété **typée déclarée mais jamais assignée**.
Les gardes autour de `ref`, `label` et `thirdparty` laissaient donc
`getTooltipContentArray()`, `getNomUrl()` et `getKanbanView()` les lire quand même.

Tout objet dont le `fetch()` a échoué — enregistrement supprimé, id à 0, colonne absente
après une migration non jouée — faisait tomber la page entière au lieu d'afficher une ligne
incomplète.

Constaté sur la liste des contrôles DigiQuali : `Sheet::fetch()` échouait sur toutes les
lignes et `getNomUrl()` levait `Typed property Sheet::$label must not be accessed before initialization`.

## Correction

`isset()` à la place de `property_exists()` — il couvre les deux cas, non initialisée et null.
Les autres `property_exists()` du fichier sont suivis d'un `!empty()`, déjà sûr, et ne bougent pas.

`getKanbanView()` garde aussi `getLibStatut()` : `LibStatut()` attend un `int` et `$status`
vaut `null` sur un objet jamais renseigné.

## Vérification

Script de non-régression sur un `Sheet` neuf (sans `fetch()`), Dolibarr chargé :

| Cas | Avant | Après |
|---|---|---|
| `getNomUrl(addLabel=1)`, tooltip ajax | Fatal | OK |
| `getNomUrl(addLabel=1)`, tooltip inline | Fatal | OK |
| `getTooltipContentArray()` | Fatal | OK |
| `getKanbanView()` | Fatal | OK |
| Fiche correctement fetchée affiche toujours son label | OK | OK |

Liste des contrôles DigiQuali rechargée en HTTP 200, colonne Fiche renseignée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)