### PR TITLE
#2510 [LinkedObject] add: generic linkable objects management

### DIFF
--- a/core/tpl/admin/object/linked_object_view.tpl.php
+++ b/core/tpl/admin/object/linked_object_view.tpl.php
@@ -1,0 +1,116 @@
+<?php
+
+/* Copyright (C) 2022-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/admin/object/linked_object_view.tpl.php
+ * \ingroup saturne
+ * \brief   Template page to manage the objects a module may link to
+ *
+ * Expected variables, all prepared by the calling page :
+ * $langs                      - Translate object
+ * $user                       - Current user
+ * $linkableObjects            - Result of saturne_filter_linkable_objects()
+ * $enabledObjectTypes         - Result of saturne_get_enabled_linked_object_types()
+ * $linkedObjectUsage          - Result of saturne_get_linked_object_usage()
+ * $linkedObjectExtraFieldName - Extrafield name whose deletion must be confirmed
+ */
+
+print load_fiche_titre($langs->trans('LinkableElements'), '', '');
+
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->trans('Element') . '</td>';
+print '<td>' . $langs->trans('LinkedObjectUsage') . '</td>';
+print '<td class="center nowrap">';
+print $langs->trans('Status') . '<br>';
+if ($user->admin) {
+    $enableAllUrl  = $_SERVER['PHP_SELF'] . '?action=toggle_all_links&value=1&token=' . newToken();
+    $disableAllUrl = $_SERVER['PHP_SELF'] . '?action=toggle_all_links&value=0&token=' . newToken();
+
+    print '<a class="reposition commonlink linked-object-toggle" href="' . $enableAllUrl . '"';
+    print ' data-confirm-message="' . dol_escape_htmltag($langs->trans('EnableAllLinksConfirm')) . '">';
+    print ' <u>' . $langs->trans('All') . '</u> </a>';
+    print ' / ';
+    print '<a class="reposition commonlink linked-object-toggle" href="' . $disableAllUrl . '"';
+    print ' data-confirm-message="' . dol_escape_htmltag($langs->trans('DisableAllLinksConfirm')) . '">';
+    print ' <u>' . $langs->trans('None') . '</u> </a>';
+}
+print '</td></tr>';
+
+foreach ($linkableObjects as $objectType => $objectMetadata) {
+    $isEnabled   = in_array($objectType, $enabledObjectTypes, true);
+    $objectLabel = $langs->trans($objectMetadata['langs']);
+    $linkCount   = $linkedObjectUsage[$objectType]['links'];
+    $valueCount  = $linkedObjectUsage[$objectType]['extrafields'][$linkedObjectExtraFieldName];
+
+    $toggleUrl  = $_SERVER['PHP_SELF'] . '?action=toggle_link&objecttype=' . urlencode($objectType);
+    $toggleUrl .= '&value=' . ($isEnabled ? 0 : 1) . '&token=' . newToken();
+
+    $statusPicto = $isEnabled
+        ? img_picto($langs->trans('Enabled'), 'switch_on')
+        : img_picto($langs->trans('Disabled'), 'switch_off');
+
+    print '<tr class="oddeven">';
+
+    print '<td>';
+    print img_picto('', $objectMetadata['picto'], 'class="pictofixedwidth"');
+    print $objectLabel;
+    print '</td>';
+
+    print '<td>';
+    if ($linkCount > 0 || $valueCount > 0) {
+        print $langs->trans('LinkedObjectUsageDetail', $linkCount, $valueCount);
+    } else {
+        print '<span class="opacitymedium">' . $langs->trans('NoLinkedObjectUsage') . '</span>';
+    }
+    print '</td>';
+
+    print '<td class="center">';
+    if ($user->admin) {
+        // The confirmation is only rendered when switching off would really destroy values.
+        $confirmMessage = '';
+        if ($isEnabled && $valueCount > 0) {
+            $confirmMessage = $langs->trans('DisableLinkConfirm', $objectLabel, $valueCount);
+        }
+
+        print '<a class="linked-object-toggle" href="' . $toggleUrl . '"';
+        print ' data-confirm-message="' . dol_escape_htmltag($confirmMessage) . '">';
+        print $statusPicto;
+        print '</a>';
+    } else {
+        print $statusPicto;
+    }
+    print '</td>';
+
+    print '</tr>';
+}
+
+print '</table>';
+
+if ($user->admin) {
+    $cleanUrl = $_SERVER['PHP_SELF'] . '?action=clean_unused_links&token=' . newToken();
+
+    print '<div class="tabsAction">';
+    print '<div class="inline-block divButAction">';
+    print '<a class="butAction linked-object-toggle" href="' . $cleanUrl . '"';
+    print ' data-confirm-message="' . dol_escape_htmltag($langs->trans('CleanUnusedLinksConfirm')) . '">';
+    print $langs->trans('CleanUnusedLinks');
+    print '</a>';
+    print '</div>';
+    print '</div>';
+}

--- a/js/modules/linkedObject.js
+++ b/js/modules/linkedObject.js
@@ -1,0 +1,89 @@
+/* Copyright (C) 2022-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    js/modules/linkedObject.js
+ * \ingroup saturne
+ * \brief   JavaScript linkedObject file for module Saturne
+ */
+
+/**
+ * Init linkedObject JS
+ *
+ * @memberof Saturne_Framework_Linkedobject
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @type {Object}
+ */
+window.saturne.linkedObject = {};
+
+/**
+ * LinkedObject init
+ *
+ * @memberof Saturne_Framework_Linkedobject
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.saturne.linkedObject.init = function() {
+  window.saturne.linkedObject.event();
+};
+
+/**
+ * LinkedObject event
+ *
+ * @memberof Saturne_Framework_Linkedobject
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @returns {void}
+ */
+window.saturne.linkedObject.event = function() {
+  $(document).on('click', '.linked-object-toggle', window.saturne.linkedObject.confirmToggle);
+};
+
+/**
+ * Ask for confirmation before a destructive link change
+ *
+ * The message is rendered server side : an empty attribute means the action destroys nothing.
+ *
+ * @memberof Saturne_Framework_Linkedobject
+ *
+ * @since   1.0.0
+ * @version 1.0.0
+ *
+ * @param  {Object}  event Triggered event
+ * @returns {boolean}      False when the user cancels, true otherwise
+ */
+window.saturne.linkedObject.confirmToggle = function(event) {
+  var confirmMessage = $(this).attr('data-confirm-message');
+
+  if (!confirmMessage) {
+    return true;
+  }
+
+  if (!window.confirm(confirmMessage)) {
+    event.preventDefault();
+    return false;
+  }
+
+  return true;
+};

--- a/lib/linked_object.lib.php
+++ b/lib/linked_object.lib.php
@@ -198,3 +198,92 @@ function saturne_get_linked_object_usage(
 
     return $usage;
 }
+
+/**
+ * Add or remove the extrafields carried by the linked objects
+ *
+ * Idempotent : adding an already declared extrafield and deleting an absent one are both no-ops,
+ * so the function can be replayed at will.
+ *
+ * Only the objects present in $linkableObjects are touched. An extrafield left on the table of a
+ * module that no longer contributes metadata is deliberately kept : that module may simply be
+ * disabled, and dropping its column would destroy data.
+ *
+ * @param  array $definitions        Extrafield definitions, each one holding the keys name, label, type,
+ *                                   pos, size, default_value, param, alwayseditable, list, langfile,
+ *                                   enabled, and object_types. An empty object_types means every enabled
+ *                                   object, a filled one restricts the definition to the listed types.
+ * @param  array $linkableObjects    Result of saturne_filter_linkable_objects()
+ * @param  array $enabledObjectTypes Result of saturne_get_enabled_linked_object_types()
+ * @return array                     ['added' => string[], 'deleted' => string[], 'errors' => int]
+ */
+function saturne_sync_linked_object_extrafields(
+    array $definitions,
+    array $linkableObjects,
+    array $enabledObjectTypes
+): array {
+    global $db;
+
+    require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
+
+    $extraFields = new ExtraFields($db);
+    $report      = ['added' => [], 'deleted' => [], 'errors' => 0];
+
+    $extraFieldNames = [];
+    foreach ($definitions as $definition) {
+        $extraFieldNames[] = $definition['name'];
+    }
+    $existingExtraFields = saturne_get_existing_extrafields($extraFieldNames);
+
+    foreach ($definitions as $definition) {
+        foreach ($linkableObjects as $objectType => $objectMetadata) {
+            $tableElement = $objectMetadata['table_element'];
+
+            $restrictedTypes = $definition['object_types'];
+
+            $isEnabled  = in_array($objectType, $enabledObjectTypes, true);
+            $isInScope  = empty($restrictedTypes) || in_array($objectType, $restrictedTypes, true);
+            $isWanted   = $isEnabled && $isInScope;
+            $isDeclared = isset($existingExtraFields[$definition['name']][$tableElement]);
+
+            if ($isWanted && !$isDeclared) {
+                $result = $extraFields->addExtraField(
+                    $definition['name'],
+                    $definition['label'],
+                    $definition['type'],
+                    $definition['pos'],
+                    $definition['size'],
+                    $tableElement,
+                    0,
+                    0,
+                    $definition['default_value'],
+                    $definition['param'],
+                    $definition['alwayseditable'],
+                    '',
+                    $definition['list'],
+                    '',
+                    '',
+                    0,
+                    $definition['langfile'],
+                    $definition['enabled']
+                );
+
+                if ($result > 0) {
+                    $report['added'][] = $definition['name'] . ' @ ' . $tableElement;
+                } else {
+                    $report['errors']++;
+                }
+            } elseif (!$isWanted && $isDeclared) {
+                $result = $extraFields->delete($definition['name'], $tableElement);
+
+                if ($result >= 0) {
+                    $report['deleted'][] = $definition['name'] . ' @ ' . $tableElement;
+                } else {
+                    $report['errors']++;
+                }
+            }
+        }
+    }
+
+    return $report;
+}

--- a/lib/linked_object.lib.php
+++ b/lib/linked_object.lib.php
@@ -287,3 +287,43 @@ function saturne_sync_linked_object_extrafields(
 
     return $report;
 }
+
+/**
+ * Rebuild the tabs and module parts a module registers into the database
+ *
+ * The module descriptor is instantiated again on purpose : it reads the configuration constants in
+ * its constructor, so a fresh instance is the only way to pick up a constant changed in the same
+ * request. delete_tabs() wipes every _TABS_ constant and delete_module_parts() wipes the declared
+ * module part constants, so the rebuild is a full replacement, not a patch.
+ *
+ * Must be called from a web request : in CLI the tabs and objects injected by other modules through
+ * hooks are not loaded, and rebuilding would silently drop them.
+ *
+ * @param  string $moduleDirectory Module directory under htdocs/custom, example 'digiquali'
+ * @param  string $moduleClassName Descriptor class name, example 'modDigiQuali'
+ * @return array                   ['tabs' => int, 'hooks' => int, 'errors' => int]
+ */
+function saturne_refresh_module_registrations(string $moduleDirectory, string $moduleClassName): array
+{
+    global $db;
+
+    $classPath = dol_buildpath('/' . $moduleDirectory . '/core/modules/' . $moduleClassName . '.class.php', 0);
+    if (!file_exists($classPath)) {
+        return ['tabs' => 0, 'hooks' => 0, 'errors' => 1];
+    }
+
+    require_once $classPath;
+
+    $module = new $moduleClassName($db);
+
+    $errors  = $module->delete_tabs();
+    $errors += $module->insert_tabs();
+    $errors += $module->delete_module_parts();
+    $errors += $module->insert_module_parts();
+
+    return [
+        'tabs'   => is_array($module->tabs) ? count($module->tabs) : 0,
+        'hooks'  => isset($module->module_parts['hooks']) ? count($module->module_parts['hooks']) : 0,
+        'errors' => $errors
+    ];
+}

--- a/lib/linked_object.lib.php
+++ b/lib/linked_object.lib.php
@@ -28,9 +28,9 @@
  * Alias entries, duplicated table elements and the objects excluded by the caller are dropped, so that
  * a consumer iterating on the result never processes the same database table twice.
  *
- * @param  array $objectsMetadata          Result of saturne_get_objects_metadata()
- * @param  array $excludedLinkNamePrefixes Link name prefixes to drop, example ['digiquali_']
- * @return array                           Subset of $objectsMetadata, original keys preserved
+ * @param  array<string, array<string, mixed>> $objectsMetadata          Result of saturne_get_objects_metadata()
+ * @param  string[]                            $excludedLinkNamePrefixes Prefixes to drop, ex. ['digiquali_']
+ * @return array<string, array<string, mixed>>                           Subset of $objectsMetadata, keys kept
  */
 function saturne_filter_linkable_objects(array $objectsMetadata, array $excludedLinkNamePrefixes = []): array
 {
@@ -64,9 +64,9 @@ function saturne_filter_linkable_objects(array $objectsMetadata, array $excluded
 /**
  * Get the object types whose link is enabled by configuration
  *
- * @param  array  $linkableObjects Result of saturne_filter_linkable_objects()
- * @param  string $constPrefix     Configuration constant prefix, example 'DIGIQUALI_SHEET_LINK_'
- * @return array                   List of enabled object types
+ * @param  array<string, array<string, mixed>> $linkableObjects Result of saturne_filter_linkable_objects()
+ * @param  string                              $constPrefix     Constant prefix, ex. 'DIGIQUALI_SHEET_LINK_'
+ * @return string[]                                             List of enabled object types
  */
 function saturne_get_enabled_linked_object_types(array $linkableObjects, string $constPrefix): array
 {
@@ -86,8 +86,8 @@ function saturne_get_enabled_linked_object_types(array $linkableObjects, string 
  *
  * Read once and reused, so that a missing column never turns into a failing count query.
  *
- * @param  array $extraFieldNames Extrafield names to look for
- * @return array                  name => [elementtype => true]
+ * @param  string[]                           $extraFieldNames Extrafield names to look for
+ * @return array<string, array<string, bool>>                  name => [elementtype => true]
  */
 function saturne_get_existing_extrafields(array $extraFieldNames): array
 {
@@ -124,10 +124,10 @@ function saturne_get_existing_extrafields(array $extraFieldNames): array
  * Feeds the usage column of an admin page, sizes the confirmation shown before a destructive
  * toggle, and lets a module backward keep every link that already carries data.
  *
- * @param  array $linkableObjects    Result of saturne_filter_linkable_objects()
- * @param  array $extraFieldNames    Extrafield names to count, example ['qc_frequency']
- * @param  array $linkedElementTypes Element types on the module side, example ['digiquali_control']
- * @return array                     objectType => ['links' => int, 'extrafields' => [name => int]]
+ * @param  array<string, array<string, mixed>> $linkableObjects    Result of saturne_filter_linkable_objects()
+ * @param  string[]                            $extraFieldNames    Extrafield names to count, example ['qc_frequency']
+ * @param  string[]                            $linkedElementTypes Module side types, ex. ['digiquali_control']
+ * @return array<string, array{links: int, extrafields: array<string, int>}> objectType => usage counters
  */
 function saturne_get_linked_object_usage(
     array $linkableObjects,
@@ -209,13 +209,15 @@ function saturne_get_linked_object_usage(
  * module that no longer contributes metadata is deliberately kept : that module may simply be
  * disabled, and dropping its column would destroy data.
  *
- * @param  array $definitions        Extrafield definitions, each one holding the keys name, label, type,
- *                                   pos, size, default_value, param, alwayseditable, list, langfile,
- *                                   enabled, and object_types. An empty object_types means every enabled
- *                                   object, a filled one restricts the definition to the listed types.
- * @param  array $linkableObjects    Result of saturne_filter_linkable_objects()
- * @param  array $enabledObjectTypes Result of saturne_get_enabled_linked_object_types()
- * @return array                     ['added' => string[], 'deleted' => string[], 'errors' => int]
+ * @param  array<int, array<string, mixed>>    $definitions        Extrafield definitions, each one holding the keys
+ *                                                                 name, label, type, pos, size, default_value, param,
+ *                                                                 alwayseditable, list, langfile, enabled and
+ *                                                                 object_types. An empty object_types means every
+ *                                                                 enabled object, a filled one restricts the
+ *                                                                 definition to the listed types.
+ * @param  array<string, array<string, mixed>> $linkableObjects    Result of saturne_filter_linkable_objects()
+ * @param  string[]                            $enabledObjectTypes Result of saturne_get_enabled_linked_object_types()
+ * @return array{added: string[], deleted: string[], errors: int}  Synchronisation report
  */
 function saturne_sync_linked_object_extrafields(
     array $definitions,
@@ -299,9 +301,9 @@ function saturne_sync_linked_object_extrafields(
  * Must be called from a web request : in CLI the tabs and objects injected by other modules through
  * hooks are not loaded, and rebuilding would silently drop them.
  *
- * @param  string $moduleDirectory Module directory under htdocs/custom, example 'digiquali'
- * @param  string $moduleClassName Descriptor class name, example 'modDigiQuali'
- * @return array                   ['tabs' => int, 'hooks' => int, 'errors' => int]
+ * @param  string $moduleDirectory                          Module directory under htdocs/custom, example 'digiquali'
+ * @param  string $moduleClassName                          Descriptor class name, example 'modDigiQuali'
+ * @return array{tabs: int, hooks: int, errors: int}         Number of tabs and hooks written, and error count
  */
 function saturne_refresh_module_registrations(string $moduleDirectory, string $moduleClassName): array
 {

--- a/lib/linked_object.lib.php
+++ b/lib/linked_object.lib.php
@@ -1,0 +1,82 @@
+<?php
+
+/* Copyright (C) 2022-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    lib/linked_object.lib.php
+ * \ingroup saturne
+ * \brief   Library files with common functions to drive linked objects from a module admin page
+ */
+
+/**
+ * Keep only the object types a module may actually link to
+ *
+ * Alias entries, duplicated table elements and the objects excluded by the caller are dropped, so that
+ * a consumer iterating on the result never processes the same database table twice.
+ *
+ * @param  array $objectsMetadata          Result of saturne_get_objects_metadata()
+ * @param  array $excludedLinkNamePrefixes Link name prefixes to drop, example ['digiquali_']
+ * @return array                           Subset of $objectsMetadata, original keys preserved
+ */
+function saturne_filter_linkable_objects(array $objectsMetadata, array $excludedLinkNamePrefixes = []): array
+{
+    $linkableObjects = [];
+    $seenTables      = [];
+
+    foreach ($objectsMetadata as $objectType => $objectMetadata) {
+        if (!empty($objectMetadata['alias_of'])) {
+            continue;
+        }
+
+        $tableElement = $objectMetadata['table_element'] ?? '';
+        if (empty($tableElement) || isset($seenTables[$tableElement])) {
+            continue;
+        }
+
+        $linkName = $objectMetadata['link_name'] ?? '';
+        foreach ($excludedLinkNamePrefixes as $excludedLinkNamePrefix) {
+            if (strpos($linkName, $excludedLinkNamePrefix) === 0) {
+                continue 2;
+            }
+        }
+
+        $seenTables[$tableElement]    = true;
+        $linkableObjects[$objectType] = $objectMetadata;
+    }
+
+    return $linkableObjects;
+}
+
+/**
+ * Get the object types whose link is enabled by configuration
+ *
+ * @param  array  $linkableObjects Result of saturne_filter_linkable_objects()
+ * @param  string $constPrefix     Configuration constant prefix, example 'DIGIQUALI_SHEET_LINK_'
+ * @return array                   List of enabled object types
+ */
+function saturne_get_enabled_linked_object_types(array $linkableObjects, string $constPrefix): array
+{
+    $enabledObjectTypes = [];
+
+    foreach (array_keys($linkableObjects) as $objectType) {
+        if (getDolGlobalInt($constPrefix . strtoupper($objectType)) > 0) {
+            $enabledObjectTypes[] = $objectType;
+        }
+    }
+
+    return $enabledObjectTypes;
+}

--- a/lib/linked_object.lib.php
+++ b/lib/linked_object.lib.php
@@ -80,3 +80,121 @@ function saturne_get_enabled_linked_object_types(array $linkableObjects, string 
 
     return $enabledObjectTypes;
 }
+
+/**
+ * Get the tables on which the given extrafields are currently declared
+ *
+ * Read once and reused, so that a missing column never turns into a failing count query.
+ *
+ * @param  array $extraFieldNames Extrafield names to look for
+ * @return array                  name => [elementtype => true]
+ */
+function saturne_get_existing_extrafields(array $extraFieldNames): array
+{
+    global $db;
+
+    $existingExtraFields = [];
+
+    if (empty($extraFieldNames)) {
+        return $existingExtraFields;
+    }
+
+    $escapedNames = [];
+    foreach ($extraFieldNames as $extraFieldName) {
+        $escapedNames[] = "'" . $db->escape($extraFieldName) . "'";
+    }
+
+    $sql  = 'SELECT name, elementtype FROM ' . MAIN_DB_PREFIX . 'extrafields';
+    $sql .= ' WHERE name IN (' . implode(', ', $escapedNames) . ')';
+
+    $resql = $db->query($sql);
+    if ($resql) {
+        while ($obj = $db->fetch_object($resql)) {
+            $existingExtraFields[$obj->name][$obj->elementtype] = true;
+        }
+        $db->free($resql);
+    }
+
+    return $existingExtraFields;
+}
+
+/**
+ * Measure how much each linkable object is actually used
+ *
+ * Feeds the usage column of an admin page, sizes the confirmation shown before a destructive
+ * toggle, and lets a module backward keep every link that already carries data.
+ *
+ * @param  array $linkableObjects    Result of saturne_filter_linkable_objects()
+ * @param  array $extraFieldNames    Extrafield names to count, example ['qc_frequency']
+ * @param  array $linkedElementTypes Element types on the module side, example ['digiquali_control']
+ * @return array                     objectType => ['links' => int, 'extrafields' => [name => int]]
+ */
+function saturne_get_linked_object_usage(
+    array $linkableObjects,
+    array $extraFieldNames,
+    array $linkedElementTypes
+): array {
+    global $db;
+
+    $usage             = [];
+    $objectTypeByLink  = [];
+    $tableByObjectType = [];
+
+    foreach ($linkableObjects as $objectType => $objectMetadata) {
+        $usage[$objectType] = ['links' => 0, 'extrafields' => []];
+        foreach ($extraFieldNames as $extraFieldName) {
+            $usage[$objectType]['extrafields'][$extraFieldName] = 0;
+        }
+
+        $objectTypeByLink[$objectMetadata['link_name']] = $objectType;
+        $tableByObjectType[$objectType]                 = $objectMetadata['table_element'];
+    }
+
+    if (!empty($linkedElementTypes)) {
+        $escapedElementTypes = [];
+        foreach ($linkedElementTypes as $linkedElementType) {
+            $escapedElementTypes[] = "'" . $db->escape($linkedElementType) . "'";
+        }
+        $inClause = implode(', ', $escapedElementTypes);
+
+        $sql  = 'SELECT sourcetype, targettype, COUNT(*) as nb';
+        $sql .= ' FROM ' . MAIN_DB_PREFIX . 'element_element';
+        $sql .= ' WHERE sourcetype IN (' . $inClause . ') OR targettype IN (' . $inClause . ')';
+        $sql .= ' GROUP BY sourcetype, targettype';
+
+        $resql = $db->query($sql);
+        if ($resql) {
+            while ($obj = $db->fetch_object($resql)) {
+                $isSourceOnModuleSide = in_array($obj->sourcetype, $linkedElementTypes, true);
+                $linkedSide           = $isSourceOnModuleSide ? $obj->targettype : $obj->sourcetype;
+                if (isset($objectTypeByLink[$linkedSide])) {
+                    $usage[$objectTypeByLink[$linkedSide]]['links'] += (int) $obj->nb;
+                }
+            }
+            $db->free($resql);
+        }
+    }
+
+    $existingExtraFields = saturne_get_existing_extrafields($extraFieldNames);
+
+    foreach ($tableByObjectType as $objectType => $tableElement) {
+        foreach ($extraFieldNames as $extraFieldName) {
+            if (!isset($existingExtraFields[$extraFieldName][$tableElement])) {
+                continue;
+            }
+
+            $sql  = 'SELECT COUNT(*) as nb FROM ' . MAIN_DB_PREFIX . $tableElement . '_extrafields';
+            $sql .= ' WHERE ' . $extraFieldName . " IS NOT NULL AND " . $extraFieldName . " <> ''";
+
+            $resql = $db->query($sql);
+            if ($resql) {
+                $obj = $db->fetch_object($resql);
+
+                $usage[$objectType]['extrafields'][$extraFieldName] = (int) $obj->nb;
+                $db->free($resql);
+            }
+        }
+    }
+
+    return $usage;
+}

--- a/lib/object.lib.php
+++ b/lib/object.lib.php
@@ -552,7 +552,10 @@ function saturne_get_objects_metadata(string $type = ''): array
             'class_path'     => 'custom/saturne/class/task/saturnetask.class.php',
             'lib_path'       => 'core/lib/project.lib.php',
         ];
-        $objectsMetadata['project_task'] = $objectsMetadata['task'];
+        //@todo backward compatibility
+        // Task::$element is 'project_task', so the object is still reachable with that legacy key
+        $objectsMetadata['project_task']             = $objectsMetadata['task'];
+        $objectsMetadata['project_task']['alias_of'] = 'task';
     }
 
     if (isModEnabled('facture')) {

--- a/lib/saturne_functions.lib.php
+++ b/lib/saturne_functions.lib.php
@@ -27,6 +27,7 @@ require_once __DIR__ . '/medias.lib.php';
 require_once __DIR__ . '/pagination.lib.php';
 require_once __DIR__ . '/documents.lib.php';
 require_once __DIR__ . '/object.lib.php';
+require_once __DIR__ . '/linked_object.lib.php';
 require_once __DIR__ . '/debug.lib.php';
 require_once __DIR__ . '/component.lib.php';
 require_once __DIR__ . '/dolibarr.lib.php';

--- a/tests/phpunit/unit/LinkedObjectLibTest.php
+++ b/tests/phpunit/unit/LinkedObjectLibTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/* Copyright (C) 2022-2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Saturne\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use stdClass;
+
+/**
+ * Tests for the pure selection helpers of lib/linked_object.lib.php
+ *
+ * Only the functions that need neither database nor Dolibarr runtime are covered here.
+ * The database bound helpers are verified by the inspection scripts described in the plan.
+ */
+class LinkedObjectLibTest extends TestCase
+{
+    /**
+     * Load linked_object.lib.php once for the entire class.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/../../../lib/linked_object.lib.php';
+    }
+
+    /**
+     * Each test starts from an empty constant set.
+     */
+    protected function setUp(): void
+    {
+        global $conf;
+
+        $conf->global = new stdClass();
+    }
+
+    // ─── saturne_filter_linkable_objects ──────────────────────────────────────
+
+    public function testFilterDropsAliasEntries(): void
+    {
+        $objectsMetadata = [
+            'contract' => ['link_name' => 'contrat', 'table_element' => 'contrat'],
+            'contrat'  => ['link_name' => 'contrat', 'table_element' => 'contrat', 'alias_of' => 'contract'],
+        ];
+
+        $result = saturne_filter_linkable_objects($objectsMetadata);
+
+        $this->assertSame(['contract'], array_keys($result));
+    }
+
+    public function testFilterDeduplicatesOnTableElement(): void
+    {
+        $objectsMetadata = [
+            'task'         => ['link_name' => 'project_task', 'table_element' => 'projet_task'],
+            'project_task' => ['link_name' => 'project_task', 'table_element' => 'projet_task'],
+        ];
+
+        $result = saturne_filter_linkable_objects($objectsMetadata);
+
+        $this->assertSame(['task'], array_keys($result));
+    }
+
+    public function testFilterDropsExcludedLinkNamePrefixes(): void
+    {
+        $objectsMetadata = [
+            'product'          => ['link_name' => 'product', 'table_element' => 'product'],
+            'digiquali_survey' => ['link_name' => 'digiquali_survey', 'table_element' => 'digiquali_survey'],
+        ];
+
+        $result = saturne_filter_linkable_objects($objectsMetadata, ['digiquali_']);
+
+        $this->assertSame(['product'], array_keys($result));
+    }
+
+    public function testFilterDropsEntriesWithoutTableElement(): void
+    {
+        $objectsMetadata = [
+            'product' => ['link_name' => 'product', 'table_element' => 'product'],
+            'broken'  => ['link_name' => 'broken'],
+        ];
+
+        $result = saturne_filter_linkable_objects($objectsMetadata);
+
+        $this->assertSame(['product'], array_keys($result));
+    }
+
+    public function testFilterKeepsMetadataUntouched(): void
+    {
+        $objectsMetadata = [
+            'product' => ['link_name' => 'product', 'table_element' => 'product', 'picto' => 'product'],
+        ];
+
+        $result = saturne_filter_linkable_objects($objectsMetadata);
+
+        $this->assertSame('product', $result['product']['picto']);
+    }
+
+    // ─── saturne_get_enabled_linked_object_types ──────────────────────────────
+
+    public function testEnabledTypesKeepsOnlyConstantsSetToOne(): void
+    {
+        global $conf;
+
+        $conf->global->DIGIQUALI_SHEET_LINK_PRODUCT = 1;
+        $conf->global->DIGIQUALI_SHEET_LINK_TICKET  = 0;
+
+        $linkableObjects = [
+            'product' => ['link_name' => 'product', 'table_element' => 'product'],
+            'ticket'  => ['link_name' => 'ticket', 'table_element' => 'ticket'],
+        ];
+
+        $result = saturne_get_enabled_linked_object_types($linkableObjects, 'DIGIQUALI_SHEET_LINK_');
+
+        $this->assertSame(['product'], $result);
+    }
+
+    public function testEnabledTypesUppercasesCompositeObjectType(): void
+    {
+        global $conf;
+
+        $conf->global->DIGIQUALI_SHEET_LINK_DOLIMEET_TRAINSESS = 1;
+
+        $linkableObjects = [
+            'dolimeet_trainsess' => ['link_name' => 'dolimeet_trainsess', 'table_element' => 'dolimeet_session'],
+        ];
+
+        $result = saturne_get_enabled_linked_object_types($linkableObjects, 'DIGIQUALI_SHEET_LINK_');
+
+        $this->assertSame(['dolimeet_trainsess'], $result);
+    }
+
+    public function testEnabledTypesTreatsMissingConstantAsDisabled(): void
+    {
+        $linkableObjects = ['bom' => ['link_name' => 'bom', 'table_element' => 'bom']];
+
+        $result = saturne_get_enabled_linked_object_types($linkableObjects, 'DIGIQUALI_SHEET_LINK_');
+
+        $this->assertSame([], $result);
+    }
+}


### PR DESCRIPTION
Mécanique générique permettant à un module Saturne de piloter ses objets liés depuis sa page d'administration, au lieu de tout créer à l'activation. Premier consommateur : DigiQuali (voir la PR liée).

## Ajouts

**`lib/linked_object.lib.php`**

| Fonction | Rôle |
|---|---|
| `saturne_filter_linkable_objects()` | Déduplique la métadonnée : retire les alias, les doublons de `table_element` et les préfixes exclus par l'appelant |
| `saturne_get_enabled_linked_object_types()` | Liste les types dont la constante `<prefix><TYPE>` vaut 1 |
| `saturne_get_existing_extrafields()` | Tables portant réellement un extrafield, lu une seule fois |
| `saturne_get_linked_object_usage()` | Usage réel par objet : liens `element_element` et valeurs d'extrafield |
| `saturne_sync_linked_object_extrafields()` | Ajout/suppression idempotents des extrafields |
| `saturne_refresh_module_registrations()` | Reconstruit onglets et module parts sur un descripteur réinstancié |

**`core/tpl/admin/object/linked_object_view.tpl.php`** — tableau « Éléments liables » : picto, colonne Utilisation, toggle, raccourcis Tout/Aucun, bouton de nettoyage. Aucune logique métier, tout est préparé par la page appelante.

**`js/modules/linkedObject.js`** — confirmation avant un basculement destructif, message rendu côté serveur dans `data-confirm-message`.

**`tests/phpunit/unit/LinkedObjectLibTest.php`** — 8 tests unitaires sur les fonctions pures.

## Correctif

`lib/object.lib.php` : `project_task` dupliquait `task` sans se déclarer `alias_of`, contrairement à `contrat`. Tout consommateur de la métadonnée traitait donc l'objet deux fois.

## Points de conception

- **Remplacement complet, pas patch.** `delete_tabs()` purge tous les `_TABS_%` et `delete_module_parts()` les constantes de parts déclarées : la reconstruction est donc idempotente par construction.
- **Contexte web obligatoire** pour `saturne_refresh_module_registrations()` : en CLI les onglets et objets injectés par hook ne sont pas chargés et seraient silencieusement perdus. C'est documenté dans le docblock.
- **Les objets absents de la métadonnée ne sont jamais touchés** : un module temporairement désactivé disparaît de `saturne_get_objects_metadata()`, supprimer ses colonnes détruirait des données.

## Vérification

- PHPUnit : 48 tests, 58 assertions, OK (à lancer depuis `htdocs/custom/saturne` — `DOL_DOCUMENT_ROOT` est déduit du chemin du bootstrap).
- PHPCS PSR-12 : 0 erreur, 0 avertissement sur les fichiers ajoutés.
- JSHint : 0 erreur.
- Idempotence de la synchro vérifiée en base : seconde passe à 0 ajout, 0 suppression, 0 erreur.

⚠️ **La PR DigiQuali associée dépend de celle-ci et ne doit pas être mergée avant.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)