### PR TITLE
#1486 [IHM] fix: keep list rows one line high when a cell holds rich html

### DIFF
--- a/css/scss/modules/_modules.scss
+++ b/css/scss/modules/_modules.scss
@@ -24,3 +24,4 @@
 @forward "list-presets/list-presets";
 @forward "list-columns/list-columns";
 @forward "list-sticky/list-sticky";
+@forward "list-cell/list-cell";

--- a/css/scss/modules/list-cell/_list-cell.scss
+++ b/css/scss/modules/list-cell/_list-cell.scss
@@ -1,0 +1,23 @@
+// List cell truncation for rich content
+//
+// Dolibarr's .tdoverflowmax* classes set white-space: nowrap on the <td>, which truncates plain
+// text but not markup : an html field carrying <h2>, <ul> or <li> renders block elements that open
+// their own line boxes, so the row grows to the full height of the description while its width
+// stays correctly capped. Forcing the descendants inline lets the parent truncation apply.
+
+table.liste td[class*="tdoverflowmax"] {
+    * {
+        display: inline;
+        margin: 0;
+        padding: 0;
+        font-size: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+        list-style: none;
+    }
+
+    br,
+    img {
+        display: none;
+    }
+}


### PR DESCRIPTION
Closes #1486

## Problème

Sur `digiquali/view/sheet/sheet_list.php`, une ligne dont la description est riche mesurait **1323 px** contre 49 px pour les autres : un seul modèle occupait tout l'écran.

## Cause

Les champs description sont déclarés en `'type' => 'html'` avec `tdoverflowmax200`. La classe Dolibarr ne contraint que la largeur :

```css
.tdoverflowmax200 { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
```

`white-space: nowrap` porte sur le `<td>`, mais les `<h2>`, `<ul>` et `<li>` du HTML de la description sont des éléments de **type bloc** : ils ouvrent leurs propres lignes, que le `nowrap` du parent n'empêche pas. La largeur restait donc correcte et seule la hauteur explosait — ce qui donne l'impression trompeuse que la troncature ne fonctionne pas, et explique qu'on cherche le problème du côté de la largeur.

## Correctif

Nouveau partiel `css/scss/modules/list-cell/_list-cell.scss` : les descendants d'une cellule de liste porteuse d'une classe `tdoverflowmax*` passent en `display: inline`, ce qui laisse la troncature du parent s'appliquer réellement.

Générique et sans configuration : toute liste de tout module Saturne en profite, aucun champ à annoter.

## Vérification

Hauteurs des 8 premières lignes, mesurées au navigateur :

| Liste | Avant | Après |
|---|---|---|
| modèles DigiQuali | **1323** | 49 |
| questions | 87 | 87 |
| groupes de questions | 49 | 49 |
| contrôles | 134 | 134 |
| questionnaires | 204 | 204 |
| produits (Dolibarr core) | 49 | 49 |
| tiers (Dolibarr core) | 49 | 49 |

Seules les lignes réellement gonflées par du HTML bloc changent ; les listes dont la hauteur vient d'un contenu multi-colonnes légitime sont inchangées, et les listes Dolibarr standard ne bougent pas.

L'ellipse de fin de ligne s'affiche correctement, la largeur de colonne est inchangée (222 px).

`css/saturne.min.css` n'est pas commité : la CI `build-assets` le régénère.

🤖 Generated with [Claude Code](https://claude.com/claude-code)