### PR TITLE
#1488 [Dashboard] feat: rendre les graphes du tableau de bord cliquables

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
   "strict": "implied",
   "globals": {
     "angular": false,
+    "Chart": false,
     "module": false,
     "require": false,
     "URLSearchParams": true,

--- a/class/saturnedashboard.class.php
+++ b/class/saturnedashboard.class.php
@@ -389,6 +389,26 @@ class SaturneDashboard
     }
 
     /**
+     * Get the hidden input holding the options the dashboard JS needs to enhance a graph
+     *
+     * Dashboard graphs are drawn on a canvas by DolGraph, which handles neither a link per bar nor a second Y
+     * axis, so both are declared here and applied by the dashboard JS.
+     *
+     * @param  array  $options Graph options: 'links' holds the URL each bar opens, in the order of the data rows,
+     *                         'datasetLinks' the same thing per dataset when the series do not share a filter,
+     *                         and 'secondAxisDataset' the index of the dataset to move to its own Y axis
+     * @return string          Hidden input to append to the graph title, empty when no bar links anywhere
+     */
+    public static function getGraphOptionsInput(array $options): string
+    {
+        if (empty($options['links']) && empty($options['datasetLinks'])) {
+            return '';
+        }
+
+        return '<input type="hidden" class="dashboard-graph-options" value="' . dol_escape_htmltag(json_encode($options, JSON_UNESCAPED_UNICODE)) . '">';
+    }
+
+    /**
      * get color range for key
      *
      * @param  int    $key Key to find in color array

--- a/class/task/saturnetask.class.php
+++ b/class/task/saturnetask.class.php
@@ -24,6 +24,8 @@
 
 require_once DOL_DOCUMENT_ROOT . '/projet/class/task.class.php';
 
+require_once __DIR__ . '/../saturnedashboard.class.php';
+
 //require_once __DIR__ . '/digiriskstats.php';
 
 /**
@@ -161,6 +163,18 @@ class SaturneTask extends Task
                 }
             }
         }
+
+        // The task list reads its progress criteria with natural_search, which understands the comparison
+        // operators. '<1' rather than '0' because the list ignores a criteria equal to the empty string, and
+        // '0' is one of them
+        $listUrl = DOL_URL_ROOT . '/projet/tasks/list.php?' . ($projectId > 0 ? 'id=' . $projectId . '&' : '') . 'search_task_progress=';
+        $links   = [
+            $listUrl . urlencode('<1'),
+            $listUrl . urlencode('>0 <100'),
+            $listUrl . urlencode('>=100')
+        ];
+
+        $array['morehtmlright'] = SaturneDashboard::getGraphOptionsInput(['links' => $links]);
 
         return $array;
     }
@@ -340,10 +354,6 @@ class SaturneTask extends Task
         $sql .= " LEFT JOIN " . MAIN_DB_PREFIX . "societe as s ON p.fk_soc = s.rowid";
         $sql .= ") AS selector";
         $sql .= " WHERE fk_element = task_id AND project_linked_id = project_id";
-        // La table element_time est partagée entre types d'élément, sans ce filtre une ligne d'un autre type serait rattachée à la tâche de même rowid
-        if ($versionEighteenOrMore) {
-            $sql .= " AND elementtype = 'task'";
-        }
         $sql .= " AND task_entity IN (" . getEntity('project') . ")";
         if ($morewherefilter) {
             $sql .= $morewherefilter;

--- a/css/scss/element/_dashboard-box.scss
+++ b/css/scss/element/_dashboard-box.scss
@@ -1,5 +1,10 @@
 @use '../variable/variable' as *;
 
+/* Set by dashboard.js while a graph bar carrying a link is hovered */
+.dolgraph canvas.graph-bar-clickable {
+  cursor: pointer;
+}
+
 .wpeo-infobox-container {
   gap: 1em;
   width: calc(100% + 1em);

--- a/js/modules/dashboard.js
+++ b/js/modules/dashboard.js
@@ -65,6 +65,9 @@ window.saturne.dashboard.event = function() {
     $(document).on('click', '#dashboard-graph-filter-submit', window.saturne.dashboard.selectDashboardFilter);
     $(document).on('click', '#dashboard-close-item', window.saturne.dashboard.closeDashboardItem);
     $(document).on('click', '#export-csv', window.saturne.dashboard.exportCSV);
+    // Bound on the document because the graphs are redrawn by AJAX each time a dashboard filter changes
+    $(document).on('click', '.dolgraph canvas', window.saturne.dashboard.openGraphLink);
+    $(document).on('mousemove', '.dolgraph canvas', window.saturne.dashboard.markGraphAsClickable);
 };
 
 /**
@@ -273,3 +276,171 @@ window.saturne.dashboard.exportCSV = function(e) {
     error: function() {}
   });
 };
+
+/**
+ * Get the options the dashboard attached to the graph a canvas belongs to
+ *
+ * Returns null for every graph without those options, so the graphs declaring none keep their default
+ * behaviour.
+ *
+ * @memberof Saturne_Dashboard
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Element}     canvas Canvas the graph is drawn on
+ * @return {Object|null}        Graph options, null when the graph carries none
+ */
+window.saturne.dashboard.getGraphOptions = function(canvas) {
+  let options = $(canvas).closest('[id^="graph-"]').find('.dashboard-graph-options').val();
+
+  return options ? JSON.parse(options) : null;
+};
+
+/**
+ * Get the Chart.js chart drawn on a canvas
+ *
+ * @memberof Saturne_Dashboard
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Element}     canvas Canvas the graph is drawn on
+ * @return {Object|null}        Chart drawn on the canvas, null when Chart.js drew none
+ */
+window.saturne.dashboard.getGraphChart = function(canvas) {
+  if (typeof Chart === 'undefined' || !Chart.getChart) {
+    return null;
+  }
+
+  return Chart.getChart(canvas);
+};
+
+/**
+ * Get the URL of the graph bar under the pointer
+ *
+ * @memberof Saturne_Dashboard
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Element} canvas Canvas the graph is drawn on
+ * @param  {Event}   event  Mouse event fired on the canvas
+ * @return {string}         URL of the bar, empty when no linked bar is under the pointer
+ */
+window.saturne.dashboard.getGraphLinkUrl = function(canvas, event) {
+  let options = window.saturne.dashboard.getGraphOptions(canvas);
+  let chart   = window.saturne.dashboard.getGraphChart(canvas);
+  if (!options || !chart) {
+    return '';
+  }
+
+  // 'nearest' resolves the single bar under the pointer, so a graph whose series each carry their own filter
+  // knows which one was clicked
+  let bars = chart.getElementsAtEventForMode(event.originalEvent || event, 'nearest', {intersect: true}, true);
+  if (!bars.length) {
+    return '';
+  }
+
+  let links = options.datasetLinks ? options.datasetLinks[bars[0].datasetIndex] : options.links;
+
+  return (links || [])[bars[0].index] || '';
+};
+
+/**
+ * Open the list the clicked graph bar links to
+ *
+ * Opened in a tab of its own, as the links of the dashboard widgets are: the dashboard is rendered by the POST
+ * of the login form when it is the page the user signed in on, and coming back to it then asks the browser to
+ * post those credentials again.
+ *
+ * @memberof Saturne_Dashboard
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Event} event Click event fired on the canvas
+ * @return {void}
+ */
+window.saturne.dashboard.openGraphLink = function(event) {
+  let url = window.saturne.dashboard.getGraphLinkUrl(this, event);
+  if (!url) {
+    return;
+  }
+
+  // Falls back on the current tab when the browser blocks the new one
+  if (!window.open(url, '_blank')) {
+    window.location.href = url;
+  }
+};
+
+/**
+ * Show the pointer cursor while a linked graph bar is hovered
+ *
+ * @memberof Saturne_Dashboard
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Event} event Mouse move event fired on the canvas
+ * @return {void}
+ */
+window.saturne.dashboard.markGraphAsClickable = function(event) {
+  let url = window.saturne.dashboard.getGraphLinkUrl(this, event);
+  $(this).toggleClass('graph-bar-clickable', url !== '');
+};
+
+/**
+ * Move the dataset declared by the graph to a Y axis of its own
+ *
+ * Two series of different magnitudes on a shared axis flatten the smaller one, and DolGraph draws every
+ * dataset against the single default axis. The scales are rewritten before the first render, so the graph is
+ * drawn once, already readable.
+ *
+ * @memberof Saturne_Dashboard
+ *
+ * @since   23.0.0
+ * @version 23.0.0
+ *
+ * @param  {Object} chart Chart.js chart being initialized
+ * @return {void}
+ */
+window.saturne.dashboard.setSecondAxis = function(chart) {
+  let options = window.saturne.dashboard.getGraphOptions(chart.canvas);
+  if (!options || options.secondAxisDataset === undefined) {
+    return;
+  }
+
+  let dataset = chart.config.data.datasets[options.secondAxisDataset];
+  if (!dataset || !chart.config.options) {
+    return;
+  }
+
+  let secondAxis = {
+    type: 'linear',
+    position: 'right',
+    beginAtZero: true,
+    // The right axis has a scale of its own, its grid lines would cross the ones of the left axis
+    grid: {drawOnChartArea: false}
+  };
+  if (typeof dataset.backgroundColor === 'string') {
+    secondAxis.ticks = {color: dataset.backgroundColor};
+  }
+
+  let scales = chart.config.options.scales || {};
+  scales.y = $.extend({type: 'linear', position: 'left', beginAtZero: true}, scales.y);
+  scales.saturneSecondAxis = secondAxis;
+
+  chart.config.options.scales = scales;
+  dataset.yAxisID = 'saturneSecondAxis';
+};
+
+/* Registered as soon as the file is evaluated rather than from init(): DolGraph creates its charts from inline
+ * scripts running while the page is parsed, long before the document is ready. The plugin is a no-op on every
+ * chart whose graph does not declare a second axis. */
+if (typeof Chart !== 'undefined' && Chart.register) {
+  Chart.register({
+    id: 'saturneDashboard',
+    beforeInit: window.saturne.dashboard.setSecondAxis
+  });
+}


### PR DESCRIPTION
## Changements

- `SaturneDashboard::getGraphOptionsInput()` : expose dans un input caché les options qu'un graphe déclare — URL de chaque barre (`links`), URL par série (`datasetLinks`), index du dataset à déporter sur un second axe Y (`secondAxisDataset`). Rendu avec le titre du graphe, donc à l'intérieur du `#graph-<nom>`.
- `js/modules/dashboard.js` : curseur main au survol d'une barre liée, ouverture de la liste au clic, et second axe appliqué via un plugin Chart.js. Le plugin est enregistré dès l'évaluation du fichier — DolGraph crée ses graphes depuis des scripts inline exécutés pendant l'analyse de la page, bien avant `document.ready` — ce qui couvre aussi les graphes réinjectés en AJAX par les filtres du tableau de bord.
- La liste s'ouvre dans un onglet à part, comme les liens des widgets du tableau de bord. Le tableau de bord est souvent la page sur laquelle l'utilisateur se connecte : il est alors rendu par le POST du formulaire de connexion, et le retour arrière déclenche « Confirmer le nouvel envoi du formulaire ».
- Graphe « Répartition des tâches » : chaque part ouvre la liste des tâches du projet filtrée sur l'avancement. La part « 0 % » filtre sur `<1` et non sur `0`, la liste ignorant un critère égal à la chaîne vide.
- `Chart` ajouté aux globales JSHint : il est fourni par Dolibarr sur toutes les pages qui dessinent un graphe.

Les `.min.js` / `.min.css` ne sont pas commités, la CI s'en charge au merge.

## Fichiers modifiés

- `class/saturnedashboard.class.php`
- `class/task/saturnetask.class.php`
- `js/modules/dashboard.js`
- `css/scss/element/_dashboard-box.scss`
- `.jshintrc`

## À savoir

Digirisk s'appuie sur `getGraphOptionsInput()` pour rendre cliquables les graphes de son tableau de bord (Evarisk/Digirisk#4970) : **cette PR doit être mergée avant celle de Digirisk**. Le tableau de bord ticket de Digirisk, qui embarquait sa propre copie de ce mécanisme, bascule sur celui-ci et supprime la sienne.

## Issue

Close #1488
