### PR TITLE
#1492 [Media] feat: add multi-upload carousel support in photo editor

### DIFF
--- a/js/modules/mediaBlock.js
+++ b/js/modules/mediaBlock.js
@@ -102,9 +102,11 @@ window.saturne.mediaBlock.onPhotoSelected = function() {
   // Reset input so the same file can be re-selected if needed
   input.val('');
 
-  // Every photo (single or series) goes through the editor sequentially so each one is
-  // resized/annotated like a single photo: validate one, the editor re-opens for the next.
-  window.saturne.mediaBlock.openFilesSequentially(filesArray, 0, module, subdir, block);
+  // Send all files to the editor in batch mode. The editor will return an array of
+  // modified File objects once the user clicks Validate All.
+  window.saturne.photoEditor.openBatch(filesArray, function(modifiedFiles) {
+    window.saturne.mediaBlock.uploadBatchFiles(filesArray, modifiedFiles, module, subdir, block);
+  });
 };
 
 /**
@@ -262,6 +264,51 @@ window.saturne.mediaBlock.openFilesSequentially = function(files, index, module,
   }
 
   window.saturne.photoEditor.openFile(files[index], onValidate, onValidateAll);
+};
+
+/**
+ * Upload an array of files in batch mode.
+ * Untouched files (which were never loaded into the canvas) are resized before uploading.
+ * Modified files (which were loaded and potentially edited) are uploaded directly.
+ *
+ * @memberof Saturne_MediaBlock
+ *
+ * @since   1.1.0
+ * @version 1.0.0
+ *
+ * @param   {Array}  originalFiles Original File objects from the input
+ * @param   {Array}  modifiedFiles File objects returned by the editor
+ * @param   {string} module        Module name
+ * @param   {string} subdir        Sub-directory
+ * @param   {jQuery} block         The .linked-medias block element
+ * @returns {void}
+ */
+window.saturne.mediaBlock.uploadBatchFiles = function(originalFiles, modifiedFiles, module, subdir, block) {
+  var index = 0;
+  
+  var processNext = function() {
+    if (index >= modifiedFiles.length) {
+      return;
+    }
+    
+    var uploadAndNext = function(blob) {
+      window.saturne.mediaBlock.uploadBlob(blob, module, subdir, block);
+      index++;
+      processNext();
+    };
+    
+    if (modifiedFiles[index] === originalFiles[index]) {
+      // Untouched file, needs resizing
+      window.saturne.photoEditor.resizeFileToBlob(originalFiles[index], function(blob) {
+        uploadAndNext(blob);
+      });
+    } else {
+      // Already modified/resized by the canvas
+      uploadAndNext(modifiedFiles[index]);
+    }
+  };
+  
+  processNext();
 };
 
 /**

--- a/js/modules/photoEditor.js
+++ b/js/modules/photoEditor.js
@@ -55,6 +55,8 @@ window.saturne.photoEditor._onSaveAll    = null;
 window.saturne.photoEditor._onDelete     = null;
 window.saturne.photoEditor._urls         = [];
 window.saturne.photoEditor._currentIndex = 0;
+window.saturne.photoEditor._files        = null;
+window.saturne.photoEditor._isBatchUpload = false;
 
 /**
  * Resolve the DOM element of a given editor tool ('pencil' is wrapped in its own container).
@@ -194,21 +196,31 @@ window.saturne.photoEditor.event = function() {
   btnPrev.addEventListener('click', function() {
     var pe = window.saturne.photoEditor;
     if (pe._urls.length < 2) return;
-    pe._currentIndex = (pe._currentIndex - 1 + pe._urls.length) % pe._urls.length;
-    pe._loadUrlIntoCanvas(pe._urls[pe._currentIndex], function() {
-      var badge = document.getElementById('saturne-photo-index-badge');
-      if (badge) badge.textContent = (pe._currentIndex + 1) + ' / ' + pe._urls.length;
-    });
+    var nextIndex = (pe._currentIndex - 1 + pe._urls.length) % pe._urls.length;
+    if (pe._isBatchUpload) {
+      pe._saveCurrentStateAndGo(nextIndex);
+    } else {
+      pe._currentIndex = nextIndex;
+      pe._loadUrlIntoCanvas(pe._urls[pe._currentIndex], function() {
+        var badge = document.getElementById('saturne-photo-index-badge');
+        if (badge) badge.textContent = (pe._currentIndex + 1) + ' / ' + pe._urls.length;
+      });
+    }
   });
 
   btnNext.addEventListener('click', function() {
     var pe = window.saturne.photoEditor;
     if (pe._urls.length < 2) return;
-    pe._currentIndex = (pe._currentIndex + 1) % pe._urls.length;
-    pe._loadUrlIntoCanvas(pe._urls[pe._currentIndex], function() {
-      var badge = document.getElementById('saturne-photo-index-badge');
-      if (badge) badge.textContent = (pe._currentIndex + 1) + ' / ' + pe._urls.length;
-    });
+    var nextIndex = (pe._currentIndex + 1) % pe._urls.length;
+    if (pe._isBatchUpload) {
+      pe._saveCurrentStateAndGo(nextIndex);
+    } else {
+      pe._currentIndex = nextIndex;
+      pe._loadUrlIntoCanvas(pe._urls[pe._currentIndex], function() {
+        var badge = document.getElementById('saturne-photo-index-badge');
+        if (badge) badge.textContent = (pe._currentIndex + 1) + ' / ' + pe._urls.length;
+      });
+    }
   });
 
   // Undo
@@ -261,10 +273,18 @@ window.saturne.photoEditor.event = function() {
         activeText.blur();
       }
       var onSaveAll = window.saturne.photoEditor._onSaveAll;
+      var isBatch = window.saturne.photoEditor._isBatchUpload;
+      var files = window.saturne.photoEditor._files;
+      var currentIndex = window.saturne.photoEditor._currentIndex;
       window.saturne.photoEditor._close();
       if (typeof onSaveAll === 'function') {
         canvas.toBlob(function(blob) {
-          onSaveAll(blob);
+          if (isBatch) {
+            files[currentIndex] = new File([blob], files[currentIndex].name, { type: 'image/jpeg', lastModified: Date.now() });
+            onSaveAll(files);
+          } else {
+            onSaveAll(blob);
+          }
         }, 'image/jpeg', 0.85);
       }
     });
@@ -381,6 +401,12 @@ window.saturne.photoEditor.open = function(urlOrUrls, onSave, startIndex, onDele
     btnOkAllEl.style.display = (typeof pe._onSaveAll === 'function') ? 'flex' : 'none';
   }
 
+  // Hide the single validate button if we are in batch upload mode
+  var btnOkEl = document.getElementById('saturne-btn-ok-photo');
+  if (btnOkEl) {
+    btnOkEl.style.display = (pe._isBatchUpload && typeof pe._onSaveAll === 'function') ? 'none' : 'flex';
+  }
+
   // Re-apply the user's tool visibility preferences
   pe._applyToolVisibility();
 
@@ -454,6 +480,40 @@ window.saturne.photoEditor.openFile = function(file, onSave, onSaveAll) {
 };
 
 /**
+ * Open the photo editor in batch mode with multiple File objects
+ *
+ * @memberof Saturne_PhotoEditor
+ *
+ * @param   {Array}    files       Array of File objects to load
+ * @param   {Function} onSaveBatch Callback receiving an array of modified File objects on validate all
+ * @returns {void}
+ */
+window.saturne.photoEditor.openBatch = function(files, onSaveBatch) {
+  var pe = window.saturne.photoEditor;
+  var urls = [];
+  for (var i = 0; i < files.length; i++) {
+    urls.push(URL.createObjectURL(files[i]));
+  }
+  
+  pe._files = files;
+  pe._isBatchUpload = true;
+  
+  // Clean up object URLs when saving
+  var onSaveBatchWrapper = function(modifiedFiles) {
+    for (var i = 0; i < urls.length; i++) {
+      if (urls[i].indexOf('blob:') === 0) {
+        URL.revokeObjectURL(urls[i]);
+      }
+    }
+    if (typeof onSaveBatch === 'function') {
+      onSaveBatch(modifiedFiles);
+    }
+  };
+
+  pe.open(urls, null, 0, null, onSaveBatchWrapper);
+};
+
+/**
  * Resize a File/Blob to the currently selected quality and return a JPEG Blob,
  * without opening the editor. Mirrors _loadUrlIntoCanvas() resize logic.
  *
@@ -499,6 +559,30 @@ window.saturne.photoEditor._close = function() {
   }
   window.saturne.photoEditor._onSave    = null;
   window.saturne.photoEditor._onSaveAll = null;
+  window.saturne.photoEditor._isBatchUpload = false;
+  window.saturne.photoEditor._files = null;
+};
+
+window.saturne.photoEditor._saveCurrentStateAndGo = function(nextIndex) {
+  var pe     = window.saturne.photoEditor;
+  var canvas = pe._canvas;
+  
+  canvas.toBlob(function(blob) {
+    var oldUrl = pe._urls[pe._currentIndex];
+    if (oldUrl.indexOf('blob:') === 0) {
+      URL.revokeObjectURL(oldUrl);
+    }
+    pe._urls[pe._currentIndex] = URL.createObjectURL(blob);
+    if (pe._files && pe._files[pe._currentIndex]) {
+      pe._files[pe._currentIndex] = new File([blob], pe._files[pe._currentIndex].name, { type: 'image/jpeg', lastModified: Date.now() });
+    }
+    
+    pe._currentIndex = nextIndex;
+    pe._loadUrlIntoCanvas(pe._urls[pe._currentIndex], function() {
+      var badge = document.getElementById('saturne-photo-index-badge');
+      if (badge) badge.textContent = (pe._currentIndex + 1) + ' / ' + pe._urls.length;
+    });
+  }, 'image/jpeg', 0.85);
 };
 
 window.saturne.photoEditor._saveState = function() {


### PR DESCRIPTION
Fixes #1492

This PR implements the requested multi-upload carousel functionality within the Saturne photo editor.

### Features
- Support for batch opening of selected images via a new window.saturne.photoEditor.openBatch method.
- Users can now navigate between multiple selected images using the previous/next arrows.
- Modifications made on a canvas (drawings/resizing) are preserved when navigating away and coming back.
- Uploads are triggered for all photos (modified or untouched) upon clicking the Validate All button.

### Implementation Details
- Uses native Blob and File object updates to maintain image state in memory (_saveCurrentStateAndGo).
- Fully respects CLAUDE.md rules (no .min commits, jQuery usage, namespace pattern).
<img width="553" height="447" alt="image" src="https://github.com/user-attachments/assets/e83403cd-7913-4b36-af4f-280ca45f11ea" />

