### PR TITLE
Fix: uninitialized typed property ActionsSaturne::resprints

### DIFF
--- a/class/actions_saturne.class.php
+++ b/class/actions_saturne.class.php
@@ -161,7 +161,7 @@ class ActionsSaturne
             $this->resprints = $out;
         }
         
-        $out = $this->resprints;
+        $out = isset($this->resprints) ? $this->resprints : '';
         $out .= "\n" . '<!-- Config Saturne injected by addHtmlHeader -->';
         $out .= "\n" . '<script>';
         $out .= "\n" . 'window.saturne = window.saturne || {};';


### PR DESCRIPTION
Fixes #1496 by checking if the property is initialized before accessing it.
