### PR TITLE
FIX: Ensure temp directory exists before copying document

### DIFF
--- a/core/tpl/actions/signature_actions.tpl.php
+++ b/core/tpl/actions/signature_actions.tpl.php
@@ -125,6 +125,11 @@ if ($action == 'builddoc') {
         $subDir    = $isSpecimen ? '/public_specimen/' : '/';
         $sourceDir = $upload_dir . '/' . strtolower($objectType) . 'document/' . $object->ref . $subDir;
         $tempDir   = DOL_DOCUMENT_ROOT . '/custom/' . $moduleNameLowerCase . '/documents/temp/';
+        
+        if (!is_dir($tempDir)) {
+            dol_mkdir($tempDir);
+        }
+        
         $originalName = $document->last_main_doc;
         $tempFileName = $isSpecimen ? 'specimen_' . $originalName : $originalName;
 


### PR DESCRIPTION
Fixes #1503
When generating a document after a signature, the document is copied to the module's 'temp' directory to allow automatic downloading. If this directory did not exist, the copy operation failed silently and the user was presented with an unavailable file link.
This PR introduces a check that creates the 'temp' directory if it does not already exist.