### PR TITLE
Fix #1507: Undefined array key and access offset on null in saturnedashboard.class.php

### DIFF
--- a/class/saturnedashboard.class.php
+++ b/class/saturnedashboard.class.php
@@ -290,9 +290,10 @@ class SaturneDashboard
                                     if ($dashboardGraph['dataset'] >= 2) {
                                             $graphData[$uniqueKey][] = $dashboardGraph['data'][$key];
                                     } else {
+                                        $label = isset($dashboardGraph['labels'][$key]['label']) ? $dashboardGraph['labels'][$key]['label'] : (string)$key;
                                         $graphData[$uniqueKey][] = [
-                                        0 => $dashboardGraph['labels'][$key]['label'],
-                                        1 => $dashboardGraph['data'][$key]
+                                            0 => $label,
+                                            1 => $dashboardGraph['data'][$key]
                                         ];
                                     }
                                 }


### PR DESCRIPTION
Fixes #1507.

Check if the label exists for a given key before trying to access it to prevent PHP warnings on the dashboard.