### PR TITLE
fix: use basename for last_main_doc to prevent path duplication

### DIFF
--- a/admin/documents.php
+++ b/admin/documents.php
@@ -246,7 +246,7 @@ if (empty($resHook)) {
                 header('Location: ' . $_SERVER['PHP_SELF'] . '?module_name=' . $moduleName . '&page_y=' . $pageY);
                 exit;
             } else {
-                header('Location: ' . DOL_URL_ROOT . '/document.php?modulepart=' . $moduleNameLowerCase . '&file=' . urlencode($moreParams['objectType'] . '/public_specimen/' . $document->last_main_doc) . '&entity=' . $conf->entity);
+                header('Location: ' . DOL_URL_ROOT . '/document.php?modulepart=' . $moduleNameLowerCase . '&file=' . urlencode($moreParams['objectType'] . '/public_specimen/' . basename($document->last_main_doc)) . '&entity=' . $conf->entity);
                 exit;
             }
         }

--- a/core/tpl/actions/signature_actions.tpl.php
+++ b/core/tpl/actions/signature_actions.tpl.php
@@ -130,7 +130,7 @@ if ($action == 'builddoc') {
             dol_mkdir($tempDir);
         }
         
-        $originalName = $document->last_main_doc;
+        $originalName = basename($document->last_main_doc);
         $tempFileName = $isSpecimen ? 'specimen_' . $originalName : $originalName;
 
         if ($isNativePdf) {

--- a/core/tpl/documents/documents_action.tpl.php
+++ b/core/tpl/documents/documents_action.tpl.php
@@ -99,7 +99,7 @@ if (($action == 'builddoc' || GETPOST('forcebuilddoc')) && $permissiontoadd) {
             if ($document->element != $documentType[0]) {
                 $document->element = $documentType[0];
             }
-            setEventMessages($langs->trans('FileGenerated') . ' - ' . '<a href=' . DOL_URL_ROOT . '/document.php?modulepart=' . (!empty($moreParams['modulePart']) ? $moreParams['modulePart'] : $object->module) . '&file=' . urlencode((empty($moreParams['modulePart']) ? $document->element . '/' : '') . (dol_strlen($object->ref) > 0 ? $object->ref . '/' : '') . $document->last_main_doc) . '&entity=' . $conf->entity . '"' . '>' . $document->last_main_doc . '</a>', []);
+            setEventMessages($langs->trans('FileGenerated') . ' - ' . '<a href=' . DOL_URL_ROOT . '/document.php?modulepart=' . (!empty($moreParams['modulePart']) ? $moreParams['modulePart'] : $object->module) . '&file=' . urlencode((empty($moreParams['modulePart']) ? $document->element . '/' : '') . (dol_strlen($object->ref) > 0 ? $object->ref . '/' : '') . basename($document->last_main_doc)) . '&entity=' . $conf->entity . '"' . '>' . basename($document->last_main_doc) . '</a>', []);
             $urlToRedirect = $_SERVER['REQUEST_URI'];
             $urlToRedirect = preg_replace('/#builddoc$/', '', $urlToRedirect);
             // To avoid infinite loop.

--- a/core/tpl/signature/public_signature_view.tpl.php
+++ b/core/tpl/signature/public_signature_view.tpl.php
@@ -53,7 +53,7 @@
         $sourceDirDoc = $conf->$moduleNameLowerCase->multidir_output[$object->entity ?? 1] . '/' . strtolower($objectType) . 'document/' . dol_sanitizeFileName($object->ref) . '/';
         $files = dol_dir_list($sourceDirDoc, 'files', 1, '\.' . ($canServePdf ? 'pdf' : 'odt') . '$', null, 'date', SORT_DESC);
         if (!empty($document->last_main_doc)) {
-            $originalName = $document->last_main_doc;
+            $originalName = basename($document->last_main_doc);
             if ($canServePdf) $originalName = preg_replace('/\.odt$/', '.pdf', $originalName);
         } elseif (!empty($files)) {
             $originalName = $files[0]['name'];


### PR DESCRIPTION
Dolibarr 12+ stores the full relative path in \last_main_doc\. This causes path duplication in Saturne views which prepend the path assuming it's only a basename. This PR wraps \last_main_doc\ with \asename()\ where necessary.