### PR TITLE
fix: disable Doliletter automatically when Saturne is disabled

### DIFF
--- a/core/modules/modSaturne.class.php
+++ b/core/modules/modSaturne.class.php
@@ -144,6 +144,7 @@ class modSaturne extends DolibarrModules
             'EasyURL'          => 'easyurl',
             'GMAO'             => 'gmao',
             'DigiKanban'       => 'digikanban',
+            'DoliLetter'       => 'doliletter',
         ];
 
         // Data directories to create when module is enabled.


### PR DESCRIPTION
Since Doliletter relies on Saturne for core features (signatures, mail, documents), disabling Saturne should automatically disable Doliletter to prevent fatal errors.