### PR TITLE
fix(#1513): ajouter priseo, fraispro et suppliercontract aux dépendances

### DIFF
--- a/core/modules/modSaturne.class.php
+++ b/core/modules/modSaturne.class.php
@@ -145,6 +145,9 @@ class modSaturne extends DolibarrModules
             'GMAO'             => 'gmao',
             'DigiKanban'       => 'digikanban',
             'DoliLetter'       => 'doliletter',
+            'Priseo'           => 'priseo',
+            'Fraispro'         => 'fraispro',
+            'SupplierContract' => 'suppliercontract',
         ];
 
         // Data directories to create when module is enabled.


### PR DESCRIPTION
Resolves #1513.
Ajoute Priseo, Fraispro et SupplierContract à la liste des modules automatiquement désactivés lors de la désactivation de Saturne.