### PR TITLE
#1519 [Config] add: set CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP on module install

### DIFF
--- a/core/modules/modSaturne.class.php
+++ b/core/modules/modSaturne.class.php
@@ -208,7 +208,8 @@ class modSaturne extends DolibarrModules
 
             // CONST DOLIBARR
             $i++ => ['MAIN_ALLOW_SVG_FILES_AS_IMAGES', 'integer', 1, '', 0, 'current'],
-            $i   => ['MAIN_CACHE_COUNT ', 'integer', 1, '', 0, 'current']
+            $i++ => ['MAIN_CACHE_COUNT ', 'integer', 1, '', 0, 'current'],
+            $i   => ['CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP', 'integer', 1, '', 0, 'current']
 
 		];
 


### PR DESCRIPTION
Closes #1519

## Problème

Les tags/catégories Dolibarr ne s'affichent en natif dans les menus (au lieu du popup) que si `CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP` vaut 1. Aucun module Evarisk ne la posait :

- absente de `$this->const` dans `modSaturne.class.php` et `modDigiriskDolibarr.class.php`
- absente des SQL d'update
- seul reedcrm la propose, via un toggle manuel dans `admin/propal.php`

Chaque client devait donc l'ajouter à la main dans Accueil > Configuration > Divers.

## Correction

Ajout de la constante au bloc `// CONST DOLIBARR` de `$this->const` dans `modSaturne.class.php`. Comme tous les modules Evarisk dépendent de Saturne, ils en héritent tous.

`insert_const()` du core ne fait un INSERT que si la constante n'existe pas (`DolibarrModules.class.php`) : aucun risque d'écraser un client qui l'aurait volontairement mise à 0.

## Tests

- `insert_const()` en CLI sur une base sans la constante → `CATEGORY_EDIT_IN_MENU_NOT_IN_POPUP = 1` (entity 1, visible 0)
- Playwright sur `societe/list.php` : 3 entrées natives dans le menu gauche (Tags/catégories clients/prosp., fournisseurs, de contacts) ; `product/list.php` : entrée Tags/catégories. Avant la modification : aucun lien.

## Limite connue

Les constantes ne sont posées qu'à l'activation du module : les installations existantes devront réactiver Saturne.

Demande initiale : Evarisk/Digirisk#4739

🤖 Generated with [Claude Code](https://claude.com/claude-code)